### PR TITLE
Fix `ij_fcghg` declaration issue

### DIFF
--- a/model/RAD_COM.f
+++ b/model/RAD_COM.f
@@ -906,7 +906,7 @@ C**** Local variables initialised in init_RAD
      &     ,ij_sw_as_noa=1
      &     ,ij_lw_as_noa=1
 
-#ifdef ACCMIP_LIKE_DIAGS
+#if ( defined ACCMIP_LIKE_DIAGS ) || ( defined TRACERS_GC )
 !@var IJ_fcghg GHG forcing diagnostics (2=LW,SW, 4=CH4,N2O,CFC11,CFC12)
       integer, dimension(2,4) :: ij_fcghg
 #endif


### PR DESCRIPTION
Closes #4.

Currently, the `dev/giss-gc-orig` branch only declares `ij_fcghg` if the `ACCMIP_LIKE_DIAGS` preprocessor option is defined. However, it is also used under the `TRACERS_GC` preprocessor option in `DEFACC.f`. This PR ensures that the array gets declared in both cases.