### PR TITLE
Tell git to ignore everything in the decks directory apart from the Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ build/*
 *.pik
 spack-build.*
 spconfig.py
+decks/*
+!decks/Makefile
+


### PR DESCRIPTION
Make is currently generating the following untracked files which we don't want to check into the repo:
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	decks/E6F40_TEST_GC_ORIG
	decks/E6F40_TEST_GC_ORIG.R
	decks/E6F40_TEST_GC_ORIG.mk
	decks/E6F40_TEST_GC_ORIG_bin/
	decks/GISS_GC_TEST2
	decks/GISS_GC_TEST2.R
	decks/GISS_GC_TEST2.mk
	decks/GISS_GC_TEST2_bin/

Tell git to ignore everything in the decks directory apart from the Makefile so that we no longer receive warnings from git about untracked files.