### PR TITLE
Account for separate NetCDF libs when building tools

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -43,6 +43,12 @@ jobs:
         git submodule init
         git submodule update
 
+    - name: Build tools
+      run: |
+        . /opt/spack-environment/activate.sh
+        cd ${GISS_HOME}/model/mk_diags
+        /bin/bash /compscr
+
     - name: Create fake inputs
       run: |
         # Make run directories

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         . /opt/spack-environment/activate.sh
         cd ${GISS_HOME}/model/mk_diags
-        /bin/bash /compscr
+        /bin/bash compscr
 
     - name: Create fake inputs
       run: |

--- a/model/mk_diags/compscr
+++ b/model/mk_diags/compscr
@@ -7,8 +7,8 @@ fc="your_fortran_compiler_name" # e.g. ifort
 
 fccmd=$(nf-config --fc)
 fccmd+=" -cpp -fallow-argument-mismatch"
-nclib=$(nf-config --flibs)
-ncinc=$(nf-config --fflags)
+nclib="$(nf-config --flibs) $(nc-config --libs)"
+ncinc="$(nf-config --fflags) $(nc-config --cflags)"
 
 echo "executing compscr with arguments:"
 echo


### PR DESCRIPTION
Closes #35.

The compilation script `compscr` for GISS Model E's `mk_diags` tools assume the NetCDF C and Fortran libraries to be in the same location. This isn't the case for our Spack build so we should account for this.