### PR TITLE
Use `MODEL_GISS` rather than `MODEL_CLASSIC`

### DIFF
--- a/model/geos-chem/CMakeLists.txt
+++ b/model/geos-chem/CMakeLists.txt
@@ -34,7 +34,7 @@ include(GC-Helpers)
 #-----------------------------------------------------------------------------
 get_repo_version(GC_REPO_VERSION ${CMAKE_CURRENT_SOURCE_DIR})
 message("=================================================================")
-message("GCClassic ${PROJECT_VERSION} (superproject wrapper)")
+message("GISS-GC ${PROJECT_VERSION} (superproject wrapper)")
 message("Current status: ${GC_REPO_VERSION}")
 message("=================================================================")
 
@@ -222,7 +222,7 @@ if(NOT GC_EXTERNAL_CONFIG)
    gc_pretty_print(VARIABLE RUNDIR)
 
    # Configure for GCClassic
-   include(GC-ConfigureClassic)
+   include(GC-ConfigureGISS-GC)
    configureGCClassic()
 
 endif()

--- a/model/geos-chem/CMakeLists.txt
+++ b/model/geos-chem/CMakeLists.txt
@@ -1,4 +1,4 @@
-# GCClassic high-level CMakeLists.txt
+# GISS-GC high-level CMakeLists.txt
 
 cmake_minimum_required (VERSION 3.13)
 project (geos-chem-classic
@@ -221,9 +221,13 @@ if(NOT GC_EXTERNAL_CONFIG)
    set(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT FALSE)
    gc_pretty_print(VARIABLE RUNDIR)
 
-   # Configure for GCClassic
+   # # Configure for GCClassic
+   # include(GC-ConfigureGCClassic)
+   # configureGCClassic()
+
+   # Configure for GISS-GC
    include(GC-ConfigureGISS-GC)
-   configureGCClassic()
+   configureGISS_GC()
 
 endif()
 

--- a/model/geos-chem/CMakeScripts/GC-ConfigureGISS-GC.cmake
+++ b/model/geos-chem/CMakeScripts/GC-ConfigureGISS-GC.cmake
@@ -1,0 +1,272 @@
+function(configureGISS_GC)
+
+    #-------------------------------------------------------------------------
+    # Find OpenMP if we're building a multithreaded executable
+    #-------------------------------------------------------------------------
+    gc_pretty_print(SECTION "Threading")
+    set(OMP ON CACHE STRING
+        "Switch to enable/disable OpenMP threading in GEOS-Chem"
+    )
+    gc_pretty_print(VARIABLE OMP IS_BOOLEAN)
+    if("${OMP}")
+       set(NO_OMP "OFF" CACHE STRING "Boolean opposite of the OMP switch, needed for backwards compatibility")
+       find_package(OpenMP REQUIRED)
+       #######################################################################
+       # NOTE: Newer versions of CMake (maybe > 3.8) prefer OpenMP::OpenMP
+       # rather than ${OpenMP_Fortran_FLAGS} to specify compilation options
+       # for OpenMP.  However, this is not supported in older versions.
+       # For backwards compatibility, especially with Azure DevOps, we will
+       # leave the new syntax commented out.  It can be restored later.
+       #
+       #  -- Bob Yantosca (28 Jul 2020)
+       #    target_compile_options(HEMCOBuildProperties
+       #      INTERFACE OpenMP::OpenMP_Fortran
+       #    )
+       #    target_link_libraries(HEMCOBuildProperties
+       #      INTERFACE OpenMP::OpenMP_Fortran
+       #    )
+       #######################################################################
+       target_compile_options(GEOSChemBuildProperties
+           INTERFACE ${OpenMP_Fortran_FLAGS}
+       )
+       target_link_libraries(GEOSChemBuildProperties
+           INTERFACE ${OpenMP_Fortran_FLAGS}
+       )
+    else()
+        set(NO_OMP "ON" CACHE STRING
+	  "Boolean opposite of the OMP switch, for backwards compatibility")
+        target_compile_definitions(GEOSChemBuildProperties
+		INTERFACE "NO_OMP"
+        )
+    endif()
+
+    # Header for next section
+    gc_pretty_print(SECTION "General settings")
+
+    #-------------------------------------------------------------------------
+    # Make MECH an option. This controls which KPP directory is used.
+    #-------------------------------------------------------------------------
+    set(MECH "fullchem" CACHE STRING "Name of the chemistry mechanism to use")
+    gc_pretty_print(VARIABLE MECH OPTIONS "fullchem" "carbon" "Hg" "custom")
+
+    #-------------------------------------------------------------------------
+    # Set USE_REAL8 as cache variable so as to not override existing definition
+    # See https://github.com/geoschem/geos-chem/issues/43.
+    #-------------------------------------------------------------------------
+    set(USE_REAL8 ON CACHE BOOL
+      "Switch to set flexible precision 8-byte floating point real"
+    )
+    gc_pretty_print(VARIABLE USE_REAL8 IS_BOOLEAN)
+    target_compile_definitions(GEOSChemBuildProperties
+      INTERFACE $<$<BOOL:${USE_REAL8}>:USE_REAL8>
+    )
+
+    #-------------------------------------------------------------------------
+    # Add code sanitization options (GNU Fortran only)
+    # We need to add these options to both compiler & linker.
+    #-------------------------------------------------------------------------
+    set(SANITIZE OFF CACHE BOOL
+        "Switch to turn on code sanitation (i.e. identify memory leaks and similar conditions)"
+    )
+    gc_pretty_print(VARIABLE SANITIZE IS_BOOLEAN)
+    if(${SANITIZE})
+      if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+	target_compile_options(GEOSChemBuildProperties
+          INTERFACE "-fsanitize=address"
+	)
+	target_link_libraries(GEOSChemBuildProperties
+          INTERFACE "-fsanitize=address"
+	)
+	target_compile_options(GEOSChemBuildProperties
+          INTERFACE "-fsanitize=leak"
+	)
+	target_link_libraries(GEOSChemBuildProperties
+          INTERFACE "-fsanitize=leak"
+	)
+	target_compile_options(GEOSChemBuildProperties
+          INTERFACE "-fsanitize=undefined"
+	)
+	target_link_libraries(GEOSChemBuildProperties
+          INTERFACE "-fsanitize=undefined"
+	)
+      else()
+        message( FATAL_ERROR "The SANITIZE option is only defined for GNU Fortran.")
+      endif()
+    endif()
+
+    #-------------------------------------------------------------------------
+    # GISS-GC
+    #-------------------------------------------------------------------------
+    target_compile_definitions(GEOSChemBuildProperties
+	INTERFACE MODEL_GISS MODEL_ EXTERNAL_GRID EXTERNAL_FORCINGS
+    )
+
+    # Header for next section
+    gc_pretty_print(SECTION "Components")
+
+    #-------------------------------------------------------------------------
+    # Build TOMAS
+    #-------------------------------------------------------------------------
+    set(TOMAS "OFF" CACHE BOOL "Switch to enable TOMAS")
+    set(TOMAS_BINS "NA" CACHE STRING "Number of TOMAS bins (only used if TOMAS is true)")
+    gc_pretty_print(VARIABLE TOMAS IS_BOOLEAN)
+    gc_pretty_print(VARIABLE TOMAS_BINS OPTIONS "NA" "15" "40")
+    if(${TOMAS})
+        target_compile_definitions(GEOSChemBuildProperties INTERFACE TOMAS)
+        if("${TOMAS_BINS}" MATCHES "NA")
+            message(FATAL_ERROR "TOMAS_BINS must be 15 or 40 if TOMAS is ON")
+        endif()
+    else()
+        if(NOT "${TOMAS_BINS}" MATCHES "NA")
+            message(FATAL_ERROR "TOMAS_BINS must be NA if TOMAS is OFF")
+        endif()
+    endif()
+    
+
+    if("${TOMAS_BINS}" MATCHES 15)
+        target_compile_definitions(GEOSChemBuildProperties
+            INTERFACE TOMAS15
+        )
+    elseif("${TOMAS_BINS}" MATCHES 40)
+        target_compile_definitions(GEOSChemBuildProperties
+            INTERFACE TOMAS40
+        )
+    endif()
+    
+    #-------------------------------------------------------------------------
+    # Build APM?
+    #-------------------------------------------------------------------------
+    set(APM "OFF" CACHE BOOL
+    	"Switch to build APM as a component of GEOS-Chem"
+    )
+    gc_pretty_print(VARIABLE APM IS_BOOLEAN)
+    if(${APM})
+        target_compile_definitions(GEOSChemBuildProperties INTERFACE APM)
+    endif()
+
+    #-------------------------------------------------------------------------
+    # Build RRTMG?
+    #-------------------------------------------------------------------------
+    set(RRTMG "OFF" CACHE BOOL
+        "Switch to build RRTMG as a component of GEOS-Chem"
+    )
+    gc_pretty_print(VARIABLE RRTMG IS_BOOLEAN)
+    if(${RRTMG})
+        target_compile_definitions(GEOSChemBuildProperties INTERFACE RRTMG)
+    endif()
+
+    #-------------------------------------------------------------------------
+    # Build GTMM?
+    # (This is a deprecated option...needs updating.  Turn OFF by default.)
+    #-------------------------------------------------------------------------
+    set(GTMM OFF CACHE BOOL
+        "Switch to build GTMM as a component of GEOS-Chem"
+    )
+    gc_pretty_print(VARIABLE GTMM IS_BOOLEAN)
+    if(${GTMM})
+        target_compile_definitions(GEOSChemBuildProperties INTERFACE GTMM_Hg)
+    endif()
+
+    #-------------------------------------------------------------------------
+    # Build HEMCO standalone?
+    #-------------------------------------------------------------------------
+    set(HCOSA "OFF" CACHE BOOL
+        "Switch to build the hemco-standalone (HCOSA) executable"
+    )
+    gc_pretty_print(VARIABLE HCOSA IS_BOOLEAN)
+
+    #-------------------------------------------------------------------------
+    # Build Luo et al wetdep scheme?
+    # (Currently a research option... turn OFF by default)
+    #-------------------------------------------------------------------------
+    set(LUO_WETDEP OFF CACHE BOOL
+        "Switch to build the Luo et al (2020) wetdep scheme into GEOS-Chem"
+    )
+    gc_pretty_print(VARIABLE LUO_WETDEP IS_BOOLEAN)
+    if(${LUO_WETDEP})
+        target_compile_definitions(GEOSChemBuildProperties
+            INTERFACE LUO_WETDEP
+        )
+    endif()
+
+    #-------------------------------------------------------------------------
+    # Use Fast-JX rather than Cloud-J?
+    #-------------------------------------------------------------------------
+    set(FASTJX OFF CACHE BOOL
+        "Switch to use legacy FAST-JX in GEOS-Chem"
+    )
+    gc_pretty_print(VARIABLE FASTJX IS_BOOLEAN)
+    if(${FASTJX})
+        #---------------------------------------------------------------------
+        # Throw an error unless we are using the Hg mechanism,
+        # The fullchem & custom mechanisms now use Cloud-J!
+        if(NOT ${MECH} MATCHES "Hg")
+          message(FATAL_ERROR "FASTJX can only be used with the Hg mechanism!")
+        endif()
+        #---------------------------------------------------------------------
+        target_compile_definitions(GEOSChemBuildProperties
+            INTERFACE FASTJX
+        )
+    endif()
+
+    #-------------------------------------------------------------------------
+    # Export the following variables to GEOS-Chem directory's scope
+    #-------------------------------------------------------------------------
+    set(GCHP                    FALSE                       PARENT_SCOPE)
+    # LTM: Need to set this to false to get GISS-GC to compile
+    set(MODEL_CLASSIC           FALSE                       PARENT_SCOPE)
+    set(MECH                    ${MECH}                     PARENT_SCOPE)
+    set(TOMAS                   ${TOMAS}                    PARENT_SCOPE)
+    set(APM                     ${APM}                      PARENT_SCOPE)
+    set(RRTMG                   ${RRTMG}                    PARENT_SCOPE)
+    set(GTMM                    ${GTMM}                     PARENT_SCOPE)
+    set(LUO_WETDEP              ${LUO_WETDEP}               PARENT_SCOPE)
+    set(SANITIZE                ${SANITIZE}                 PARENT_SCOPE)
+    set(FASTJX                  ${FASTJX}                   PARENT_SCOPE)
+
+    #-------------------------------------------------------------------------
+    # Export information about Git status
+    #-------------------------------------------------------------------------
+
+    # Get branch nane in code repository
+    macro(get_git_branch VAR)
+      execute_process(
+        COMMAND git -C ${CMAKE_CURRENT_SOURCE_DIR} rev-parse --abbrev-ref HEAD
+        OUTPUT_VARIABLE ${VAR}
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+    endmacro()
+    get_git_branch(CODE_BRANCH)
+    set(GIT_BRANCH ${CODE_BRANCH} CACHE STRING "Current branch in code repo")
+
+    # Get last commit name from code repository
+    macro(get_git_commit VAR)
+      execute_process(
+        COMMAND git -C ${CMAKE_CURRENT_SOURCE_DIR} log -n 1 --pretty=format:"%s"
+        OUTPUT_VARIABLE ${VAR}
+	)
+    endmacro()
+    get_git_commit(LAST_COMMIT)
+    set(GIT_COMMIT ${LAST_COMMIT} CACHE STRING "Last commit in Git repo")
+
+    # Get last commit hash from code repository
+    macro(get_git_commit_hash VAR)
+      execute_process(
+        COMMAND git -C ${CMAKE_CURRENT_SOURCE_DIR} log -n 1 --pretty=format:"%h"
+        OUTPUT_VARIABLE ${VAR}
+	)
+    endmacro()
+    get_git_commit_hash(COMMIT_HASH)
+    set(GIT_COMMIT_HASH ${COMMIT_HASH} CACHE STRING "Last commit hash in Git repo")
+
+    # Get last commit date from code repository
+    macro(get_git_commit_date VAR)
+      execute_process(
+        COMMAND git -C ${CMAKE_CURRENT_SOURCE_DIR} log -n 1 --pretty=format:"%cd"
+        OUTPUT_VARIABLE ${VAR}
+	)
+    endmacro()
+    get_git_commit_date(COMMIT_DATE)
+    set(GIT_COMMIT_DATE ${COMMIT_DATE} CACHE STRING "Date of last Git commit")
+    
+endfunction()


### PR DESCRIPTION
Closes #44.

This PR updates the GISS-GC `develop` branch so that it builds under the `MODEL_GISS` compiler option rather than `MODEL_CLASSIC`, as was used in earlier drafts. This means we can drop several GEOS-Chem edits - see linked GEOS-Chem PR: https://github.com/fetch4/geos-chem/pull/10.

Note to reviewer: please review this PR and https://github.com/fetch4/geos-chem/pull/10 together.