### PR TITLE
Drop compiler environment variables

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -13,12 +13,6 @@ env:
   GISS_HOME: /__w/GISS-GC/GISS-GC
   ModelE_Support: /__w/GISS-GC/GISS-GC/run
   DATA: /__w/GISS-GC/GISS-GC/run/prod_input_files
-  # Environment variables for compiler
-  CC: gcc
-  CXX: g++
-  FC: gfortran
-  F90: gfortran
-  F77: gfortran
   # Misc. environment variables
   F_UFMTENDIAN: big
   KMP_STACKSIZE: 100000000


### PR DESCRIPTION
As we realised in our meeting earlier, there is no need to set `CC`, `CXX`, `FC`, `F90`, and `F77` environment variables when building GISS-GC. They can be safely dropped.