### PR TITLE
Fix command line input issue

### DIFF
--- a/config/compiler.gfortran.mk
+++ b/config/compiler.gfortran.mk
@@ -27,13 +27,14 @@ CPPFLAGS += -DCOMPILER_G95
 FFLAGS = -g -cpp -fconvert=big-endian -O2 -fno-range-check -fallow-argument-mismatch
 F90FLAGS = $(FFLAGS) -ffree-line-length-none
 LFLAGS =
-ifeq ($(GC),YES)
-LFLAGS += -nostartfiles -Wno-main
-endif
 ifeq ($(MP),YES)
 FFLAGS += -fopenmp
 F90FLAGS += -fopenmp
 LFLAGS += -fopenmp
+endif
+CTM_LFLAGS = $(LFLAGS)
+ifeq ($(GC),YES)
+CTM_LFLAGS += -nostartfiles -Wno-main
 endif
 
 F90_VERSION = $(shell $(F90) --version | head -1)

--- a/config/compiler.intel.mk
+++ b/config/compiler.intel.mk
@@ -7,15 +7,16 @@ CMP_MOD = $(SCRIPTS_DIR)/compare_module_file.pl -compiler INTEL-ifort-9-0-on-LIN
 FFLAGS = -fpp -O2 -ftz -convert big_endian
 F90FLAGS = $(FFLAGS) -free
 LFLAGS = -O2 -ftz
-ifeq ($(GC),YES)
-LFLAGS += -nostartfiles -nofor-main
-endif
 CPPFLAGS += -DCOMPILER_Intel8 -DCONVERT_BIGENDIAN
 F90_VERSION = $(shell $(F90) --version 2>&1)
 ifeq ($(MP),YES)
 FFLAGS += -qopenmp
 F90FLAGS += -qopenmp
 LFLAGS += -qopenmp
+endif
+CTM_FLAGS = $(LFLAGS)
+ifeq ($(GC),YES)
+CTM_LFLAGS += -nostartfiles -nofor-main
 endif
 R8 = -r8
 EXTENDED_SOURCE = -extend_source

--- a/decks/Makefile
+++ b/decks/Makefile
@@ -139,7 +139,7 @@ ifeq ($(GC),YES)
 		-DCMAKE_CXX_COMPILER="$(CXX)" \
 		-DCMAKE_Fortran_COMPILER="$(F90)" \
 		-DCMAKE_Fortran_FLAGS="$(F90FLAGS)" \
-		-DCMAKE_EXE_LINKER_FLAGS="$(LFLAGS)"
+		-DCMAKE_EXE_LINKER_FLAGS="$(CTM_LFLAGS)"
 	cd $(GC_BUILD_DIR) && make -j install
 	cp $(GC_BUILD_DIR)/mod/*.mod $(MODEL_DIR)/mod/
 	cp $(GC_BUILD_DIR)/src/HEMCO/mod/*.mod $(MODEL_DIR)/mod/


### PR DESCRIPTION
Closes #54.

This was my bad. Lee arrived at a working version by adding `-nostartfiles -nofor-main` (similarly for other compilers) directly to the linker flags for GEOS-Chem, which told the compiler that it shouldn't expect a main function. The model is being driven by Model E. I tried to tidy things up by moving these to the `config/compiler.*.mk` files but added them to the *main* `LFLAGS` arguments. By doing so, the compiler was also being told that Model E also doesn't have a main function either, meaning it wouldn't accept command line arguments.