### PR TITLE
Improve dev utils debugging experience

### DIFF
--- a/.dev/config/geoschem_config.yml
+++ b/.dev/config/geoschem_config.yml
@@ -17,7 +17,7 @@ simulation:
   species_database_file: ./species_database.yml
   species_metadata_output_file: OutputDir/geoschem_species_metadata.yml
   verbose:
-    activate: false
+    activate: true
     on_cores: root       # Allowed values: root all
   use_gcclassic_timers: false
 

--- a/.dev/utils/build.sh
+++ b/.dev/utils/build.sh
@@ -6,11 +6,12 @@
 set -e
 
 # Default values
+COMPILE_WITH_TRAPS=NO
+DEBUG=false
 FRESH=false
-OPENMP=false
 GISS_ONLY=false
 MECH=fullchem
-DEBUG=false
+OPENMP=false
 
 # Function to display help text
 show_help() {
@@ -21,6 +22,7 @@ show_help() {
   echo "  --openmp          Compile with OpenMP enabled."
   echo "  --giss-only       Build without GEOS-Chem coupling."
   echo "  --debug           Run with debugging turned on."
+  echo "  --traps           Run with additional 'COMPILE_WITH_TRAPS' debugging option."
   echo "  -f                Fresh rebuild of the model."
   echo "  --help            Show this help message and exit."
 }
@@ -63,6 +65,10 @@ for arg in "$@"; do
     DEBUG=true
     shift
     ;;
+  --traps)
+    COMPILE_WITH_TRAPS=YES
+    shift
+    ;;
   *)
     echo "Unknown argument: $arg"
     show_help
@@ -80,11 +86,12 @@ else
 fi
 
 # Print the values for verification
+echo "COMPILE_WITH_TRAPS=${COMPILE_WITH_TRAPS}"
+echo "DEBUG=${DEBUG}"
+echo "FRESH=${FRESH}"
+echo "GC=${GC}"
 echo "MECH=${MECH}"
 echo "OPENMP=${OPENMP}"
-echo "GC=${GC}"
-echo "FRESH=${FRESH}"
-echo "DEBUG=${DEBUG}"
 
 # Conditionally fresh rebuild of the model
 cd "${GISS_HOME}/decks"
@@ -98,7 +105,10 @@ if [ "${DEBUG}" = true ]; then
   ln -s -f "${GISS_HOME}/.github/rundecks/${RUNID}.R" "$(pwd)/${RUNID}_DEBUG.R"
   RUNID="${RUNID}_DEBUG"
   make -j setup RUN="${RUNID}" F90=mpif90 GC="${GC}" MP="${OPENMP}" MPI=YES MECH="${MECH}" \
-    TYPE=Debug DEBUG=YES COMPILE_WITH_TRAPS=YES TRACEBACK=YES OVERWRITE=YES
+    TYPE=Debug DEBUG=YES COMPILE_WITH_TRAPS="${COMPILE_WITH_TRAPS}" TRACEBACK=YES OVERWRITE=YES
+elif [ "${COMPILE_WITH_TRAPS}" = "YES" ]; then
+  echo "COMPILE_WITH_TRAPS only has an effect if debug mode is turned on. Exiting."
+  exit 0
 else
   ln -s -f "${GISS_HOME}/.github/rundecks/${RUNID}.R" "$(pwd)/${RUNID}.R"
   make -j setup RUN="${RUNID}" F90=mpif90 GC="${GC}" MP="${OPENMP}" MPI=YES MECH="${MECH}" \

--- a/.dev/utils/build.sh
+++ b/.dev/utils/build.sh
@@ -31,6 +31,16 @@ if [ "$1" = "--help" ]; then
   exit 0
 fi
 
+# Check for unset environment variables
+if [ -z ${GISS_HOME+x} ]; then
+  echo "GISS_HOME is unset. Exiting."
+  exit 0
+fi
+if [ -z ${ModelE_Support+x} ]; then
+  echo "ModelE_Support is unset. Exiting."
+  exit 0
+fi
+
 # Parse arguments
 for arg in "$@"; do
   case $arg in
@@ -77,7 +87,7 @@ echo "FRESH=${FRESH}"
 echo "DEBUG=${DEBUG}"
 
 # Conditionally fresh rebuild of the model
-cd ${GISS_HOME}/decks/
+cd "${GISS_HOME}/decks"
 if [ "${FRESH}" = true ]; then
   make clean OVERWRITE=YES
   make clean_all OVERWRITE=YES
@@ -85,32 +95,32 @@ fi
 
 # Compile
 if [ "${DEBUG}" = true ]; then
-  ln -s -f ${GISS_HOME}/.github/rundecks/${RUNID}.R $(pwd)/${RUNID}_DEBUG.R
+  ln -s -f "${GISS_HOME}/.github/rundecks/${RUNID}.R" "$(pwd)/${RUNID}_DEBUG.R"
   RUNID="${RUNID}_DEBUG"
-  make -j setup RUN=${RUNID} F90=mpif90 GC=${GC} MP=${OPENMP} MPI=YES MECH=${MECH} \
+  make -j setup RUN="${RUNID}" F90=mpif90 GC="${GC}" MP="${OPENMP}" MPI=YES MECH="${MECH}" \
     TYPE=Debug DEBUG=YES COMPILE_WITH_TRAPS=YES TRACEBACK=YES OVERWRITE=YES
 else
-  ln -s -f ${GISS_HOME}/.github/rundecks/${RUNID}.R $(pwd)/${RUNID}.R
-  make -j setup RUN=${RUNID} F90=mpif90 GC=${GC} MP=${OPENMP} MPI=YES MECH=${MECH} \
+  ln -s -f "${GISS_HOME}/.github/rundecks/${RUNID}.R" "$(pwd)/${RUNID}.R"
+  make -j setup RUN="${RUNID}" F90=mpif90 GC="${GC}" MP="${OPENMP}" MPI=YES MECH="${MECH}" \
     TYPE=Release OVERWRITE=YES
 fi
 
 if [ "${GISS_ONLY}" = false ]; then
   # Copy over configuration files
-  HUGE_SPACE=${ModelE_Support}/huge_space/${RUNID}
-  CONFIG=${GISS_HOME}/.dev/config
+  HUGE_SPACE="${ModelE_Support}/huge_space/${RUNID}"
+  CONFIG="${GISS_HOME}/.dev/config"
   for DIR in ${GISS_HOME} ${HUGE_SPACE}; do
-    ln -s -f ${CONFIG}/geoschem_config.yml ${DIR}/geoschem_config.yml
-    ln -s -f ${CONFIG}/HEMCO_Config.rc ${DIR}/HEMCO_Config.rc
-    ln -s -f ${CONFIG}/HEMCO_Diagn.rc ${DIR}/HEMCO_Diagn.rc
-    ln -s -f ${CONFIG}/HISTORY.rc ${DIR}/HISTORY.rc
-    ln -s -f ${CONFIG}/species_database.yml ${DIR}/species_database.yml
+    ln -s -f "${CONFIG}/geoschem_config.yml" "${DIR}/geoschem_config.yml"
+    ln -s -f "${CONFIG}/HEMCO_Config.rc" "${DIR}/HEMCO_Config.rc"
+    ln -s -f "${CONFIG}/HEMCO_Diagn.rc" "${DIR}/HEMCO_Diagn.rc"
+    ln -s -f "${CONFIG}/HISTORY.rc" "${DIR}/HISTORY.rc"
+    ln -s -f "${CONFIG}/species_database.yml" "${DIR}/species_database.yml"
   done
   # Create output directories
-  mkdir -p ${HUGE_SPACE}/OutputDir
+  mkdir -p "${HUGE_SPACE}/OutputDir"
   # Setup restarts
-  mkdir -p ${HUGE_SPACE}/Restarts
+  mkdir -p "${HUGE_SPACE}/Restarts"
   # NOTE: The restart file will need to have been saved in the following location
-  ln -s -f ${GC_INPUTS}/ExtData/GEOSCHEM_RESTARTS/GC_14.3.0/GEOSChem.Restart.20160701_0000z.LATEST.nc4 \
-    ${HUGE_SPACE}/Restarts/GEOSChem.Restart.20160701_0000z.nc4
+  ln -s -f "${GC_INPUTS}/ExtData/GEOSCHEM_RESTARTS/GC_14.3.0/GEOSChem.Restart.20160701_0000z.LATEST.nc4" \
+    "${HUGE_SPACE}/Restarts/GEOSChem.Restart.20160701_0000z.nc4"
 fi

--- a/.dev/utils/build.sh
+++ b/.dev/utils/build.sh
@@ -36,16 +36,6 @@ if [ "$1" = "--help" ]; then
   exit 0
 fi
 
-# Check for unset environment variables
-if [ -z ${GISS_HOME+x} ]; then
-  echo "GISS_HOME is unset. Exiting."
-  exit 0
-fi
-if [ -z ${ModelE_Support+x} ]; then
-  echo "ModelE_Support is unset. Exiting."
-  exit 0
-fi
-
 # Parse arguments
 for arg in "$@"; do
   case $arg in
@@ -84,6 +74,36 @@ for arg in "$@"; do
   esac
 done
 
+# Print the values for verification
+echo "CLASSIC=${CLASSIC}"
+echo "COMPILE_WITH_TRAPS=${COMPILE_WITH_TRAPS}"
+echo "DEBUG=${DEBUG}"
+echo "FRESH=${FRESH}"
+echo "GISS_ONLY=${GISS_ONLY}"
+echo "MECH=${MECH}"
+echo "OPENMP=${OPENMP}"
+
+# Check for unset environment variables
+if [ -z ${GISS_HOME+x} ]; then
+  echo "GISS_HOME is unset. Exiting."
+  exit 0
+fi
+if [ -z ${ModelE_Support+x} ]; then
+  echo "ModelE_Support is unset. Exiting."
+  exit 0
+fi
+if [ "${CLASSIC}" = true ]; then
+  if [ -z ${GCCLASSIC_RUNDIR+x} ]; then
+    echo "GCCLASSIC_RUNDIR is unset. Exiting."
+    exit 0
+  fi
+  if [ -z ${F90FLAGS+x} ]; then
+    echo "F90FLAGS is unset. Exiting."
+    exit 0
+  fi
+fi
+
+# Set environment variables appropriately for the chosen mode
 if [ "${GISS_ONLY}" = true ]; then
   if [ "${CLASSIC}" = true ]; then
     echo "--giss-only and --classic are mutually exclusive"
@@ -95,16 +115,8 @@ else
   GC=YES
   RUNID=GISS_GC_14
 fi
-
-# Print the values for verification
-echo "CLASSIC=${CLASSIC}"
-echo "COMPILE_WITH_TRAPS=${COMPILE_WITH_TRAPS}"
-echo "DEBUG=${DEBUG}"
-echo "FRESH=${FRESH}"
 echo "GC=${GC}"
-echo "GISS_ONLY=${GISS_ONLY}"
-echo "MECH=${MECH}"
-echo "OPENMP=${OPENMP}"
+echo "RUNID=${RUNID}"
 
 # Conditionally fresh rebuild of the model
 cd "${GISS_HOME}/decks"
@@ -118,6 +130,7 @@ if [ "${DEBUG}" = true ]; then
 else
   TYPE=Release
 fi
+echo "TYPE=${TYPE}"
 
 # Compile
 if [ "${CLASSIC}" = true ]; then
@@ -127,6 +140,7 @@ if [ "${CLASSIC}" = true ]; then
   if [ "${DEBUG}" = true ]; then
     BUILD_DIR=${BUILD_DIR}_debug
   fi
+  echo "BUILD_DIR=${BUILD_DIR}"
   if [ "${FRESH}" = true ]; then
     rm -rf ${BUILD_DIR}
   fi

--- a/.dev/utils/build.sh
+++ b/.dev/utils/build.sh
@@ -181,9 +181,9 @@ if [ "${GISS_ONLY}" = false ]; then
     ln -s -f "${CONFIG}/species_database.yml" "${DIR}/species_database.yml"
   done
   # Create output directories
-  mkdir -p "${HUGE_SPACE}/OutputDir"
+  mkdir -p "${RUNDIR}/OutputDir"
   # Setup restarts
-  mkdir -p "${HUGE_SPACE}/Restarts"
+  mkdir -p "${RUNDIR}/Restarts"
   # NOTE: The restart file will need to have been saved in the following location
   ln -s -f "${GC_INPUTS}/ExtData/GEOSCHEM_RESTARTS/GC_14.3.0/GEOSChem.Restart.20160701_0000z.LATEST.nc4" \
     "${RUNDIR}/Restarts/GEOSChem.Restart.20160701_0000z.nc4"

--- a/.dev/utils/run.sh
+++ b/.dev/utils/run.sh
@@ -65,4 +65,5 @@ fi
 # Navigate to the run directory and run the model for one hour
 cd ${ModelE_Support}/prod_runs/${RUNID}
 ./${RUNID}ln
-mpiexec -np ${NP} ./${RUNID}.exe -i I -cold-restart
+MP_SET_NUM_THREADS="${NP}" ./${RUNID} -i I -cold-restart &
+tail -f ${RUNID}.PRT

--- a/.dev/utils/run.sh
+++ b/.dev/utils/run.sh
@@ -29,6 +29,12 @@ if [ "$1" = "--help" ]; then
   exit 0
 fi
 
+# Check for unset environment variables
+if [ -z ${ModelE_Support+x} ]; then
+  echo "ModelE_Support is unset. Exiting."
+  exit 0
+fi
+
 # Parse arguments
 for arg in "$@"; do
   case $arg in
@@ -58,12 +64,12 @@ else
   RUNID=GISS_GC_14
 fi
 if [ "${DEBUG}" = true ]; then
-  ln -s -f $(pwd)/${RUNID}.R $(pwd)/${RUNID}_DEBUG.R
+  ln -s -f "$(pwd)/${RUNID}.R" "$(pwd)/${RUNID}_DEBUG.R"
   RUNID="${RUNID}_DEBUG"
 fi
 
 # Navigate to the run directory and run the model for one hour
-cd ${ModelE_Support}/prod_runs/${RUNID}
+cd "${ModelE_Support}/prod_runs/${RUNID}"
 ./${RUNID}ln
 MP_SET_NUM_THREADS="${NP}" ./${RUNID} -i I -cold-restart &
 tail -f ${RUNID}.PRT

--- a/.dev/utils/run.sh
+++ b/.dev/utils/run.sh
@@ -31,12 +31,6 @@ if [ "$1" = "--help" ]; then
   exit 0
 fi
 
-# Check for unset environment variables
-if [ -z ${ModelE_Support+x} ]; then
-  echo "ModelE_Support is unset. Exiting."
-  exit 0
-fi
-
 # Parse arguments
 for arg in "$@"; do
   case $arg in
@@ -63,6 +57,24 @@ for arg in "$@"; do
   esac
 done
 
+# Print the values for verification
+echo "CLASSIC=${CLASSIC}"
+echo "DEBUG=${DEBUG}"
+echo "GISS_ONLY=${GISS_ONLY}"
+echo "NP=${NP}"
+
+# Check for unset environment variables
+if [ -z ${ModelE_Support+x} ]; then
+  echo "ModelE_Support is unset. Exiting."
+  exit 0
+fi
+if [ "${CLASSIC}" = true ]; then
+  if [ -z ${GCCLASSIC_RUNDIR+x} ]; then
+    echo "GCCLASSIC_RUNDIR is unset. Exiting."
+    exit 0
+  fi
+fi
+
 if [ "${CLASSIC}" = true ]; then
   if [ "${NP}" != "1" ]; then
     echo "GCClassic only runs in serial"
@@ -85,6 +97,7 @@ else
     ln -s -f "$(pwd)/${RUNID}.R" "$(pwd)/${RUNID}_DEBUG.R"
     RUNID="${RUNID}_DEBUG"
   fi
+  echo "RUNID=${RUNID}"
 
   # Navigate to the run directory and run the model for one hour
   cd "${ModelE_Support}/prod_runs/${RUNID}"

--- a/.dev/utils/setup.sh
+++ b/.dev/utils/setup.sh
@@ -5,16 +5,16 @@
 
 # Environment variables for GISS modelE
 # NOTE: Path may need to be edited for your system
-export GISS_HOME=${HOME}/software/GISS-GC
+export GISS_HOME="${HOME}/software/GISS-GC"
 # NOTE: Path may need to be edited for your system
-export ModelE_Support=${HOME}/run/GISS-GC
-mkdir -p ${ModelE_Support}
+export ModelE_Support="${HOME}/run/GISS-GC"
+mkdir -p "${ModelE_Support}"
 # Environment variables for compiler
 export CC=gcc      # NOTE: C compiler may need to be modified for your system
 export CXX=g++     # NOTE: C++ compiler may need to be modified for your system
 export FC=gfortran # NOTE: Fortran compiler may need to be modified for your system
-export F90=${FC}
-export F77=${FC}
+export F90="${FC}"
+export F77="${FC}"
 # Misc. enviroment variables
 export F_UFMTENDIAN=big
 export KMP_STACKSIZE=100000000
@@ -23,25 +23,27 @@ export OMP_NUM_THREADS=1
 # Spack setup
 # NOTE: This section may need to be edited for your setup
 spack env activate -p giss-gc
-MPIF90=$(find ${SPACK_ENV} -name mpif90 | head -n 1)
+MPIF90=$(find "${SPACK_ENV}" -name mpif90 | head -n 1)
 export MPI_ROOT=${MPIF90%/bin/mpif90}
 
 # Environment variables for passing NetCDF-C paths to GEOS-Chem
-export NETCDF_HOME=$(nc-config --prefix)
-export GC_BIN=${NETCDF_HOME}/bin
-export GC_INCLUDE=${NETCDF_HOME}/include
-export GC_LIB=${NETCDF_HOME}/lib
+NETCDF_HOME="$(nc-config --prefix)"
+export NETCDF_HOME
+export GC_BIN="${NETCDF_HOME}/bin"
+export GC_INCLUDE="${NETCDF_HOME}/include"
+export GC_LIB="${NETCDF_HOME}/lib"
 
 # Environment variables for passing NetCDF-Fortran paths to GEOS-Chem
-export NETCDF_F_HOME=$(nf-config --prefix)
-export GC_F_BIN=${NETCDF_F_HOME}/bin
-export GC_F_INCLUDE=${NETCDF_F_HOME}/include
-export GC_F_LIB=${NETCDF_F_HOME}/lib
+NETCDF_F_HOME="$(nf-config --prefix)"
+export NETCDF_F_HOME
+export GC_F_BIN="${NETCDF_F_HOME}/bin"
+export GC_F_INCLUDE="${NETCDF_F_HOME}/include"
+export GC_F_LIB="${NETCDF_F_HOME}/lib"
 
 # GEOS-Chem input data
 # NOTE: Path may need to be edited for your system
-export GC_INPUTS=${DATA}/GISS-GC/prod_input_files
-export ROOT=${GC_INPUTS}/ExtData/HEMCO/
+export GC_INPUTS="${DATA}/GISS-GC/prod_input_files"
+export ROOT="${GC_INPUTS}/ExtData/HEMCO"
 
 # Put tools in the path
-export PATH=${SOFTWARE}/tools/mk_diags:${PATH}
+export PATH="${SOFTWARE}/tools/mk_diags:${PATH}"

--- a/.github/set_gcclassic_rundir.sh
+++ b/.github/set_gcclassic_rundir.sh
@@ -3,6 +3,8 @@
 # Script for setting the GCClassic rundir in the CI                            #
 # ============================================================================ #
 
+set -eu
+
 mkdir -p "${GCCLASSIC_RUNDIR}"
 cd "${GISS_HOME}/model/geos-chem/src/GEOS-Chem/run/GCClassic"
 ./createRunDir.sh <<<"1

--- a/.github/workflows/compile_gcclassic.yml
+++ b/.github/workflows/compile_gcclassic.yml
@@ -43,7 +43,10 @@ jobs:
         password: ${{ secrets.github_token }}
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      with:
+        persist-credentials: false
+      uses: actions/checkout@v2
 
     - name: Setup submodules
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,8 @@ jobs:
       packages: write
     steps:
       - name: Checkout the repo
+        with:
+          persist-credentials: false
         uses: actions/checkout@v4
 
       - name: Setup Docker buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,11 @@ on:
   schedule:
     - cron: '0 0 1 */3 *'
 
+# Cancel jobs running if new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     name: Build Docker container

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           persist-credentials: false
         uses: actions/checkout@v4
+
       - name: Install Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,63 @@
+# Workflow to run linting checks on source
+name: Lint
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on pushes to the "main" branch, i.e., PR merges
+  push:
+    branches: [ "main" ]
+
+  # Triggers the workflow on pushes to open pull requests with code changes
+  pull_request:
+    paths:
+      - '.github/workflows/lint.yml'
+      - '.dev/utils/*.sh'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Workflow run - one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "lint"
+  lint:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout code
+        with:
+          persist-credentials: false
+        uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m venv ci_venv
+          . ci_venv/bin/activate
+          pip install zizmor==0.9.2
+          sudo apt install shellcheck
+
+      # Apply Shell linter, shellcheck
+      - name: shellcheck
+        if: always()
+        run: |
+          cd ${{ github.workspace }}/.dev/utils
+          for FILE in $(find . -name "*.sh"); do
+            shellcheck -x ${FILE}
+          done
+
+      # Apply GitHub Actions linter, zizmor
+      - name: zizmor
+        if: always()
+        run: |
+          cd ${{ github.workspace }}
+          . ci_venv/bin/activate
+          zizmor .github/workflows/*.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,9 @@ on:
   # Triggers the workflow on pushes to open pull requests with code changes
   pull_request:
     paths:
-      - '.github/workflows/lint.yml'
       - '.dev/utils/*.sh'
+      - '.github/*.sh'
+      - '.github/workflows/lint.yml'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -50,7 +51,9 @@ jobs:
       - name: shellcheck
         if: always()
         run: |
-          cd ${{ github.workspace }}/.dev/utils
+          cd ${{ github.workspace }}
+          shellcheck -x .github/set_gcclassic_rundir.sh
+          cd .dev/utils
           for FILE in $(find . -name "*.sh"); do
             shellcheck -x ${FILE}
           done

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -24,6 +24,11 @@ env:
   KMP_STACKSIZE: 100000000
   OMP_NUM_THREADS: 1
 
+# Cancel jobs running if new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Test that GISS-GC can be compiled without error
   compile:

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -35,7 +35,10 @@ jobs:
         password: ${{ secrets.github_token }}
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      with:
+        persist-credentials: false
+      uses: actions/checkout@v2
 
     - name: Setup submodules
       run: |

--- a/exec/setup_e.pl
+++ b/exec/setup_e.pl
@@ -392,7 +392,7 @@ print RUNID <<EOF;
     opts=
     touch_ifile=0
     if [ "\$NP"x = x ] ; then NP=1; fi
-    if [ "\$DEBUG_COMMAND"x = x ] ; then DEBUG_COMMAND="xterm -e gdb --args"; fi
+    if [ "\$DEBUG_COMMAND"x = x ] ; then DEBUG_COMMAND="gdb --args"; fi
     while [ \$\# -ge 1 ] ; do
       OPT=\$1 ; shift
       case \$OPT in


### PR DESCRIPTION
This PR makes various changes to improve the debugging experience in our new setup.

* Turn on verbose output for GEOS-Chem.
* Use the `./${RUNID}` executable rather than `./${RUNID}.exe` one. It properly accounts for MPI so avoids confusing MPI abort errors.
* Remove the `xterm` approach from the `gdb` debugger option built into the `${RUNID}` script. I prefer not to use this.
* Make the `COMPILE_WITH_TRAPS` option separate from general debugging. Running with `--debug` but not `--traps` then enables us to compile with debug flags but not do full bounds/memory checking.
* CI jobs for linting the `.dev/utils` shell scripts and GitHub Actions workflow files.

This PR also makes it so that running test suite or Docker workflows are cancelled if a new commit is pushed to the PR.