### PR TITLE
Turn off GISS-only SUBDDs under `TRACERS_GC`

### DIFF
--- a/model/SUBDD.f
+++ b/model/SUBDD.f
@@ -1819,18 +1819,6 @@ c add (calls to) the analogs of ijh_defs et al.
       input_sizes3(k) = lm
       call tijph_defs(diaglists(1,k),nmax_possible,diaglens(k))
 #endif
-#ifdef TRACERS_GC
-      k = k + 1
-      catshapes(k) = 'aijlh'; categories(k) = 'taijlh'
-      input_sizes3(k) = lm
-      call tijlh_defs(diaglists(1,k),nmax_possible,diaglens(k))
-
-      k = k + 1
-      catshapes(k) = 'aijh'; categories(k) = 'taijh'
-      input_sizes3(k) = 0
-      call tijh_defs(diaglists(1,k),nmax_possible,diaglens(k))
-#endif
-
 
 c
 c check whether each requested diagnostic is in the list


### PR DESCRIPTION
Related to #29.

~~@ltmurray you mentioned that we should drop all tracers starting with t in `SUBDD`. I assume that `TO3` is one such tracer. Are you recommending dropping the various temperature ones, too? (Commit fb0ab3c34259bdf795e07b934cb8ea30ac04bc86.) And in-cloud optical thickness ones well? (Commit 24de165fe2d8e330843f8b62c3b57a6b1395fb11.)~~