### PR TITLE
Fix workflow concurrency issue

### DIFF
--- a/.github/workflows/compile_giss.yml
+++ b/.github/workflows/compile_giss.yml
@@ -31,11 +31,6 @@ env:
   KMP_STACKSIZE: 100000000
   OMP_NUM_THREADS: 1
 
-# Cancel jobs running if new commits are pushed
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   # Test that GISS Model E can be compiled without error
   compile:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Cancel jobs running if new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Workflow run - one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "lint"


### PR DESCRIPTION
It seems #75 introduced a bug in one of the workflows:
https://github.com/fetch4/GISS-GC/actions/runs/13203367574
Not sure how this got through previously.

Namely, the `concurrency` configuration was set twice in one of the workflows. I removed it and added it into the linting workflow, for completeness.