### PR TITLE
Loading from checkpoint file if not cold restart (take 2)

### DIFF
--- a/model/ATM_DRV.f
+++ b/model/ATM_DRV.f
@@ -990,7 +990,7 @@ c for now, CREATE_CAP is only relevant to the cubed sphere grid
       subroutine new_io_atmvars(fid,iorw)
       use model_com, only: ioread, iowrite
 #ifdef TRACERS_GC
-      use CHEM_DRV, only : init_chem, io_chem
+      use CHEM_DRV, only : io_chem
 #endif
       implicit none
       integer, intent(in) :: fid,iorw

--- a/model/ATM_DRV.f
+++ b/model/ATM_DRV.f
@@ -799,7 +799,7 @@ C****
 
       end subroutine INPUT_atm
 
-      subroutine alloc_drv_atm()
+      subroutine alloc_drv_atm(is_coldstart)
 #ifdef SCM
       use Dictionary_mod, only : sync_param
 #endif
@@ -836,6 +836,8 @@ c set-up for MPI implementation
       include 'mpif.h'      ! Needed for GLINT2
 #endif
 
+      LOGICAL, INTENT(IN) :: is_coldstart
+
 c initialize the atmospheric domain decomposition
 c for now, CREATE_CAP is only relevant to the cubed sphere grid
       call init_grid(grid, im, jm, lm, CREATE_CAP=.true.)
@@ -843,7 +845,7 @@ c for now, CREATE_CAP is only relevant to the cubed sphere grid
       call geom_atm
 
 #if defined( TRACERS_GC )
-      call init_chem( grid )
+      call init_chem( grid, is_coldstart )
 #endif
       
 #if (defined TRACERS_ON) || (defined TRACERS_OCEAN)

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -2027,7 +2027,7 @@ CONTAINS
       ENDIF
     ELSE
       ! In the case of a non-cold-restart, initialise GEOS-Chem from the Model E restart file
-      fid = par_open( grid, trim( 'checkpoint.nc' ), 'read' )
+      fid = par_open( grid, trim( 'fort.1.nc' ), 'read' )
       CALL IO_CHEM(fid, 'read' )
       call par_close( grid, fid )
     ENDIF

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -681,7 +681,6 @@ CONTAINS
           ENDDO
        ENDDO
     ENDDO
-
     ! Set species units
     DO N=1, State_Chm%nSpecies
        State_Chm%Species(N)%Units = KG_SPECIES ! TrM is in kg

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -2176,6 +2176,11 @@ CONTAINS
       ! Determine which was the latest restart file to be written to
       call find_later_rsf(KDISK)
 
+      ! NOTE: Tried reading with io_rsf rather than the manual code below but it gave an MPI abort
+      ! USE MODEL_COM, only : ioread, Itime
+      ! INTEGER :: ioerr
+      ! call io_rsf(rsf_file_name(KDISK),Itime,ioread,ioerr)
+
       ! Read the TrM and TrMom values from the restart file in parallel
       fid = par_open( grid, trim(rsf_file_name(KDISK))//'.nc', 'read' )
       CALL IO_CHEM( fid, 'read_dist' )

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -2129,7 +2129,6 @@ CONTAINS
       fid = par_open( grid, trim( 'fort.2.nc' ), 'read' )
       CALL IO_CHEM(fid, 'read_dist' )
       call par_close( grid, fid )
-      ! TODO: More logic from Get_GC_Restart?
       DO N=1,NTM
          DO L=1,LM
             DO J=J_0,J_1

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -136,7 +136,7 @@ CONTAINS
     USE PBL_Mix_Mod,       ONLY : Compute_PBL_Height
     USE VDIFF_Mod,         ONLY : Max_PblHt_For_Vdiff
     USE ERROR_MOD,         ONLY : Safe_Div, IT_IS_NAN, ERROR_STOP
-    USE UnitConv_Mod,      ONLY : Convert_Spc_Units, KG_SPECIES, KG_SPECIES_PER_KG_DRY_AIR, &
+    USE UnitConv_Mod,      ONLY : Convert_Spc_Units, KG_SPECIES, &
                                   MOLES_SPECIES_PER_MOLES_DRY_AIR
 
     USE Photolysis_Mod,  ONLY : Init_Photolysis
@@ -1123,7 +1123,7 @@ CONTAINS
          State_Chm  = State_Chm,                                             &
          State_Grid = State_Grid,                                            &
          State_Met  = State_Met,                                             &
-         new_units    = KG_SPECIES_PER_KG_DRY_AIR,                           &
+         new_units  = KG_SPECIES_PER_KG_DRY_AIR,                             &
          previous_units   = previous_units,                                  &
          RC         = RC                                                    )
     IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "CONVERT_SPC_UNITS", 255 )
@@ -2237,7 +2237,7 @@ CONTAINS
          State_Chm  = State_Chm,                                             &
          State_Grid = State_Grid,                                            &
          State_Met  = State_Met,                                             &
-         new_units    =  MOLES_SPECIES_PER_MOLES_DRY_AIR,                    &
+         new_units  = MOLES_SPECIES_PER_MOLES_DRY_AIR,                       &
          previous_units   = previous_units,                                  &
          RC         = RC                                                    )
     IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "CONVERT_SPC_UNITS", 255 )
@@ -2583,8 +2583,8 @@ CONTAINS
             State_Chm  = State_Chm,                                           &
             State_Grid = State_Grid,                                          &
             State_Met  = State_Met,                                           &
-            new_units    = MOLECULES_SPECIES_PER_CM3,                         &
-            previous_units   = previous_units,                                &
+            new_units  = MOLECULES_SPECIES_PER_CM3,                           &
+            previous_units = previous_units,                                  &
             RC         = RC                                                  )
 
        ! Trap error

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -681,10 +681,6 @@ CONTAINS
           ENDDO
        ENDDO
     ENDDO
-    ! Set species units
-    DO N=1, State_Chm%nSpecies
-       State_Chm%Species(N)%Units = KG_SPECIES ! TrM is in kg
-    ENDDO
 
     ! Convert to v/v dry
     CALL Convert_Spc_Units(                                                  &
@@ -692,7 +688,7 @@ CONTAINS
          State_Chm  = State_Chm,                                             &
          State_Grid = State_Grid,                                            &
          State_Met  = State_Met,                                             &
-         new_units    = MOLES_SPECIES_PER_MOLES_DRY_AIR,                       &
+         new_units  = MOLES_SPECIES_PER_MOLES_DRY_AIR,                       &
          RC         = RC                                                    )
     IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
 
@@ -713,7 +709,7 @@ CONTAINS
          State_Chm  = State_Chm,                                             &
          State_Grid = State_Grid,                                            &
          State_Met  = State_Met,                                             &
-         new_units    = KG_SPECIES,                                            &
+         new_units  = KG_SPECIES,                                            &
          RC         = RC                                                    )
     IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
 

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -2017,8 +2017,8 @@ CONTAINS
        CALL Error_Stop( ErrMsg, ThisLoc, Instr )
     ENDIF
 
+    ! In the case of a cold restart, initialise GEOS-Chem from its restart file
     IF (is_coldstart) THEN
-      ! In the case of a cold restart, initialise GEOS-Chem from its restart file
       CALL Get_GC_Restart( Input_Opt, State_Chm, State_Grid, State_Met, RC )
 
       ! IF ( AM_I_ROOT() ) THEN
@@ -2031,11 +2031,6 @@ CONTAINS
         Instr  = ''
         CALL Error_Stop( ErrMsg, ThisLoc, Instr )
       ENDIF
-    ELSE
-      ! In the case of a non-cold-restart, initialise GEOS-Chem from the Model E restart file
-      fid = par_open( grid, trim( 'fort.1.nc' ), 'read' )
-      CALL IO_CHEM(fid, 'read' )
-      call par_close( grid, fid )
     ENDIF
 
     IF ( Input_Opt%useTimers ) THEN
@@ -2113,23 +2108,30 @@ CONTAINS
        ENDIF
     ENDDO
     t_qlimit(:) = .true.
+
+    ! In the case of a cold restart, copy State_Chm into TrM as kg kg-1 for now
+    ! State_Met is not populated so we can't convert to kg
     TrM    = 0d0
     TrMom  = 0d0
-    
-    ! Copy State_Chm into TrM as kg kg-1 for now
-    ! State_Met is not populated so we can't convert to kg
-    DO N=1,NTM
-       DO L=1,LM
-          DO J=J_0,J_1
-             DO I=I_0,I_1
-                II = I - I_0 + 1
-                JJ = J - J_0 + 1
-                TrM( I, J, L, N ) = State_Chm%Species(N)%Conc(II,JJ,L)
-             ENDDO
-          ENDDO
-       ENDDO
-    ENDDO
-    
+    IF (is_coldstart) THEN
+      DO N=1,NTM
+         DO L=1,LM
+            DO J=J_0,J_1
+               DO I=I_0,I_1
+                  II = I - I_0 + 1
+                  JJ = J - J_0 + 1
+                  TrM( I, J, L, N ) = State_Chm%Species(N)%Conc(II,JJ,L)
+               ENDDO
+            ENDDO
+         ENDDO
+      ENDDO
+    ELSE
+      ! In the case of a non-cold-restart, initialise GEOS-Chem from the Model E restart file
+      fid = par_open( grid, trim( 'fort.2.nc' ), 'read' )
+      CALL IO_CHEM(fid, 'read' )
+      call par_close( grid, fid )
+    ENDIF
+
     ! Return success
     RC = GC_SUCCESS
     

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -603,6 +603,11 @@ CONTAINS
             YEAR, '-', MONTH, '-', DAY, HOUR, ':', MINUTE, ':', SECOND
     ENDIF
 
+    ! Set species units
+    DO N=1, State_Chm%nSpecies
+       State_Chm%Species(N)%Units = KG_SPECIES ! TrM is in kg
+    ENDDO
+
     IF ( FIRST_CHEM ) THEN
        ! Species_Chm has initial conditions in kg kg-1 at the moment.
        ! Now that we have meteorology in State_Met, we need to convert it to kg
@@ -675,10 +680,6 @@ CONTAINS
              ENDDO
           ENDDO
        ENDDO
-    ENDDO
-    ! Set species units
-    DO N=1, State_Chm%nSpecies
-       State_Chm%Species(N)%Units = KG_SPECIES ! TrM is in kg
     ENDDO
 
     ! Convert to v/v dry

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -622,7 +622,7 @@ CONTAINS
             new_units  = KG_SPECIES,                                            &
             RC         = RC                                                    )
        IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
-       
+
        ! Put State_Chm back in TrM
        DO N=1,NTM
           DO L=1,LM
@@ -640,13 +640,23 @@ CONTAINS
           ENDDO
        ENDDO
 
+       ! Convert to v/v dry
+       CALL Convert_Spc_Units(                                                 &
+            Input_Opt  = Input_Opt,                                            &
+            State_Chm  = State_Chm,                                            &
+            State_Grid = State_Grid,                                           &
+            State_Met  = State_Met,                                            &
+            new_units  = MOLES_SPECIES_PER_MOLES_DRY_AIR,                      &
+            RC         = RC                                                   )
+       IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
+
        ! Initialize PBL quantities from the initial met fields
        CALL Compute_Pbl_Height( Input_Opt, State_Grid, State_Met, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "COMPUTE_PBL_HEIGHT" at initialization!'
           CALL Error_Stop( ErrMsg, ThisLoc )
        ENDIF
-       
+
        ! Once the initial met fields have been read in, we need to find
        ! the maximum PBL level for the non-local mixing algorithm.
        CALL Max_PblHt_For_Vdiff( Input_Opt, State_Grid, State_Met, RC )
@@ -654,7 +664,7 @@ CONTAINS
           ErrMsg = 'Error encountered in "Max_PblHt_for_Vdiff"!'
           CALL Error_Stop( ErrMsg, ThisLoc )
        ENDIF
-       
+
        ! Initialize photolysis, including reading files for optical properties
        IF ( Input_Opt%ITS_A_FULLCHEM_SIM .or. &
             Input_Opt%ITS_AN_AEROSOL_SIM .or. &
@@ -665,10 +675,20 @@ CONTAINS
              CALL Error_Stop( ErrMsg, ThisLoc )
           ENDIF
        ENDIF
-       
+
        FIRST_CHEM = .FALSE.
     ENDIF
-    
+
+    ! Convert to kg
+    CALL Convert_Spc_Units(                                                    &
+         Input_Opt  = Input_Opt,                                               &
+         State_Chm  = State_Chm,                                               &
+         State_Grid = State_Grid,                                              &
+         State_Met  = State_Met,                                               &
+         new_units  = KG_SPECIES,                                              &
+         RC         = RC                                                    )
+    IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
+
     ! Copy TrM into State_Chm
     DO N=1,NTM
        DO L=1,LM
@@ -730,9 +750,19 @@ CONTAINS
        ENDDO
     ENDDO
 
-    !IF ( AM_I_ROOT() ) THEN
-    !   WRITE(6,*) State_Chm%Species(182)%Conc(1,:,1)
-    !ENDIF
+    ! Convert to v/v dry
+    CALL Convert_Spc_Units(                                                  &
+         Input_Opt  = Input_Opt,                                             &
+         State_Chm  = State_Chm,                                             &
+         State_Grid = State_Grid,                                            &
+         State_Met  = State_Met,                                             &
+         new_units  = MOLES_SPECIES_PER_MOLES_DRY_AIR,                       &
+         RC         = RC                                                    )
+    IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
+
+    ! IF ( AM_I_ROOT() ) THEN
+    !    WRITE(6,*) State_Chm%Species(182)%Conc(1,:,1)
+    ! ENDIF
     
     !IF ( AM_I_ROOT() ) THEN
     !   WRITE(6,*) ""
@@ -1458,6 +1488,8 @@ CONTAINS
     USE Vdiff_Mod,               ONLY : Max_PblHt_for_Vdiff
 
     USE pario,                   ONLY : par_open, par_close
+    USE UnitConv_Mod,            ONLY : Convert_Spc_Units, KG_SPECIES, &
+                                        MOLES_SPECIES_PER_MOLES_DRY_AIR
 
     IMPLICIT NONE
 
@@ -2111,9 +2143,19 @@ CONTAINS
     TrMom  = 0d0
     IF (is_coldstart) THEN
       !------------------------------------------------------------------------
-      ! In the case of a cold restart, copy State_Chm into TrM as kg kg-1 for
-      ! now (State_Met is not populated so we can't convert to kg)
+      ! In the case of a cold restart, copy State_Chm into TrM with the
+      ! appropriate units
       !------------------------------------------------------------------------
+
+      ! Convert to kg
+      CALL Convert_Spc_Units(                                                  &
+          Input_Opt  = Input_Opt,                                              &
+          State_Chm  = State_Chm,                                              &
+          State_Grid = State_Grid,                                             &
+          State_Met  = State_Met,                                              &
+          new_units  = KG_SPECIES,                                             &
+          RC         = RC                                                    )
+      IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
       DO N=1,NTM
          DO L=1,LM
             DO J=J_0,J_1
@@ -2139,8 +2181,10 @@ CONTAINS
       CALL IO_CHEM( fid, 'read_dist' )
       call par_close( grid, fid )
 
-      ! The restart file has units mol mol-1 so the units are inconsistent with
-      ! the cold restart case above
+      ! Species are read from restart file in units of mol mol-1
+      DO N=1, State_Chm%nSpecies
+        State_Chm%Species(N)%Units = MOLES_SPECIES_PER_MOLES_DRY_AIR
+      ENDDO
       DO N=1,NTM
          DO L=1,LM
             DO J=J_0,J_1
@@ -2152,11 +2196,42 @@ CONTAINS
             ENDDO
          ENDDO
       ENDDO
+
+      ! Convert to kg
+      CALL Convert_Spc_Units(                                                  &
+          Input_Opt  = Input_Opt,                                              &
+          State_Chm  = State_Chm,                                              &
+          State_Grid = State_Grid,                                             &
+          State_Met  = State_Met,                                              &
+          new_units  = KG_SPECIES,                                             &
+          RC         = RC                                                    )
+      IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
+      DO N=1,NTM
+         DO L=1,LM
+            DO J=J_0,J_1
+               DO I=I_0,I_1
+                  II = I - I_0 + 1
+                  JJ = J - J_0 + 1
+                  TrM( I, J, L, N ) = State_Chm%Species(N)%Conc(II,JJ,L)
+               ENDDO
+            ENDDO
+         ENDDO
+      ENDDO
     ENDIF
+
+    ! Convert to v/v dry
+    CALL Convert_Spc_Units(                                                    &
+         Input_Opt  = Input_Opt,                                               &
+         State_Chm  = State_Chm,                                               &
+         State_Grid = State_Grid,                                              &
+         State_Met  = State_Met,                                               &
+         new_units  = MOLES_SPECIES_PER_MOLES_DRY_AIR,                         &
+         RC         = RC                                                    )
+    IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
 
     ! Return success
     RC = GC_SUCCESS
-    
+
     RETURN
   END SUBROUTINE INIT_CHEM
 

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -2128,7 +2128,7 @@ CONTAINS
     ELSE
       ! In the case of a non-cold-restart, initialise GEOS-Chem from the Model E restart file
       fid = par_open( grid, trim( 'fort.2.nc' ), 'read' )
-      CALL IO_CHEM(fid, 'read' )
+      CALL IO_CHEM(fid, 'read_dist' )
       call par_close( grid, fid )
       ! TODO: More logic from Get_GC_Restart?
       DO N=1,NTM

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -602,12 +602,13 @@ CONTAINS
             YEAR, '-', MONTH, '-', DAY, HOUR, ':', MINUTE, ':', SECOND
     ENDIF
 
-    ! Set species units
-    DO N=1, State_Chm%nSpecies
-       State_Chm%Species(N)%Units = KG_SPECIES ! TrM is in kg
-    ENDDO
-
     IF ( FIRST_CHEM ) THEN
+
+       ! Set species units to kg kg-1
+       DO N=1, State_Chm%nSpecies
+         State_Chm%Species(N)%Units = KG_SPECIES_PER_KG_DRY_AIR
+       ENDDO
+
        ! Species_Chm has initial conditions in kg kg-1 at the moment.
        ! Now that we have meteorology in State_Met, we need to convert it to kg
        ! put into TrM
@@ -679,6 +680,11 @@ CONTAINS
              ENDDO
           ENDDO
        ENDDO
+    ENDDO
+
+    ! Set species units
+    DO N=1, State_Chm%nSpecies
+       State_Chm%Species(N)%Units = KG_SPECIES ! TrM is in kg
     ENDDO
 
     ! Convert to v/v dry

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -2105,11 +2105,15 @@ CONTAINS
     ENDDO
     t_qlimit(:) = .true.
 
-    ! In the case of a cold restart, copy State_Chm into TrM as kg kg-1 for now
-    ! State_Met is not populated so we can't convert to kg
+    !-----------------------------------------------------------------------------
+
     TrM    = 0d0
     TrMom  = 0d0
     IF (is_coldstart) THEN
+      !------------------------------------------------------------------------
+      ! In the case of a cold restart, copy State_Chm into TrM as kg kg-1 for
+      ! now (State_Met is not populated so we can't convert to kg)
+      !------------------------------------------------------------------------
       DO N=1,NTM
          DO L=1,LM
             DO J=J_0,J_1
@@ -2122,11 +2126,21 @@ CONTAINS
          ENDDO
       ENDDO
     ELSE
+      !------------------------------------------------------------------------
+      ! In the case of a non-cold-restart, initialise GEOS-Chem from the Model
+      ! E restart file
+      !------------------------------------------------------------------------
+
+      ! Determine which was the latest restart file to be written to
       call find_later_rsf(KDISK)
-      ! In the case of a non-cold-restart, initialise GEOS-Chem from the Model E restart file
+
+      ! Read the TrM and TrMom values from the restart file in parallel
       fid = par_open( grid, trim(rsf_file_name(KDISK))//'.nc', 'read' )
       CALL IO_CHEM( fid, 'read_dist' )
       call par_close( grid, fid )
+
+      ! The restart file has units mol mol-1 so the units are inconsistent with
+      ! the cold restart case above
       DO N=1,NTM
          DO L=1,LM
             DO J=J_0,J_1

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -1432,7 +1432,7 @@ CONTAINS
     USE DOMAIN_DECOMP_ATM,       ONLY : DIST_GRID, Am_I_Root, getDomainBounds
     USE GEOM,                    ONLY : axyp, lat2d_dg, lon2d_dg
     USE CONSTANT,                ONLY : Pi
-    USE MODEL_COM,               ONLY : DTsrc
+    USE MODEL_COM,               ONLY : DTsrc, rsf_file_name
     USE Dictionary_mod,          ONLY : sync_param
     USE CHEM_COM,                ONLY : SpcChmID_to_TrID, t_qlimit, TrFullName, TrID_to_SpcChmID, NSP, SpName
     USE ERROR_MOD,               ONLY : Debug_Msg, Error_Stop, Init_Error
@@ -1481,6 +1481,7 @@ CONTAINS
     INTEGER   :: TAU, TAUb
 
     INTEGER   :: fid
+    INTEGER   :: KDISK
 
     CHARACTER(LEN=255)       :: ThisLoc, historyConfigFile
     CHARACTER(LEN=512)       :: ErrMsg, Instr
@@ -2125,9 +2126,10 @@ CONTAINS
          ENDDO
       ENDDO
     ELSE
+      call find_later_rsf(KDISK)
       ! In the case of a non-cold-restart, initialise GEOS-Chem from the Model E restart file
-      fid = par_open( grid, trim( 'fort.2.nc' ), 'read' )
-      CALL IO_CHEM(fid, 'read_dist' )
+      fid = par_open( grid, trim(rsf_file_name(KDISK))//'.nc', 'read' )
+      CALL IO_CHEM( fid, 'read_dist' )
       call par_close( grid, fid )
       DO N=1,NTM
          DO L=1,LM

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -604,24 +604,10 @@ CONTAINS
 
     IF ( FIRST_CHEM ) THEN
 
-       ! Set species units to kg kg-1
+       ! Set species units to kg to be put into TrM
        DO N=1, State_Chm%nSpecies
-         State_Chm%Species(N)%Units = KG_SPECIES_PER_KG_DRY_AIR
+         State_Chm%Species(N)%Units = KG_SPECIES
        ENDDO
-
-       ! Species_Chm has initial conditions in kg kg-1 at the moment.
-       ! Now that we have meteorology in State_Met, we need to convert it to kg
-       ! put into TrM
-
-       ! Convert to kg
-       CALL Convert_Spc_Units(                                                  &
-            Input_Opt  = Input_Opt,                                             &
-            State_Chm  = State_Chm,                                             &
-            State_Grid = State_Grid,                                            &
-            State_Met  = State_Met,                                             &
-            new_units  = KG_SPECIES,                                            &
-            RC         = RC                                                    )
-       IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
 
        ! Put State_Chm back in TrM
        DO N=1,NTM
@@ -639,16 +625,6 @@ CONTAINS
              CALL HALO_UPDATE( GRID, TrMom(M,:,:,:,N) )
           ENDDO
        ENDDO
-
-       ! Convert to v/v dry
-       CALL Convert_Spc_Units(                                                 &
-            Input_Opt  = Input_Opt,                                            &
-            State_Chm  = State_Chm,                                            &
-            State_Grid = State_Grid,                                           &
-            State_Met  = State_Met,                                            &
-            new_units  = MOLES_SPECIES_PER_MOLES_DRY_AIR,                      &
-            RC         = RC                                                   )
-       IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
 
        ! Initialize PBL quantities from the initial met fields
        CALL Compute_Pbl_Height( Input_Opt, State_Grid, State_Met, RC )
@@ -677,17 +653,17 @@ CONTAINS
        ENDIF
 
        FIRST_CHEM = .FALSE.
+    ELSE
+      ! Convert to kg
+      CALL Convert_Spc_Units(                                                  &
+          Input_Opt  = Input_Opt,                                              &
+          State_Chm  = State_Chm,                                              &
+          State_Grid = State_Grid,                                             &
+          State_Met  = State_Met,                                              &
+          new_units  = KG_SPECIES,                                             &
+          RC         = RC                                                    )
+      IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
     ENDIF
-
-    ! Convert to kg
-    CALL Convert_Spc_Units(                                                    &
-         Input_Opt  = Input_Opt,                                               &
-         State_Chm  = State_Chm,                                               &
-         State_Grid = State_Grid,                                              &
-         State_Met  = State_Met,                                               &
-         new_units  = KG_SPECIES,                                              &
-         RC         = RC                                                    )
-    IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
 
     ! Copy TrM into State_Chm
     DO N=1,NTM
@@ -749,16 +725,6 @@ CONTAINS
           CALL HALO_UPDATE( GRID, TrMom(M,:,:,:,N) )
        ENDDO
     ENDDO
-
-    ! Convert to v/v dry
-    CALL Convert_Spc_Units(                                                  &
-         Input_Opt  = Input_Opt,                                             &
-         State_Chm  = State_Chm,                                             &
-         State_Grid = State_Grid,                                            &
-         State_Met  = State_Met,                                             &
-         new_units  = MOLES_SPECIES_PER_MOLES_DRY_AIR,                       &
-         RC         = RC                                                    )
-    IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
 
     ! IF ( AM_I_ROOT() ) THEN
     !    WRITE(6,*) State_Chm%Species(182)%Conc(1,:,1)
@@ -2146,16 +2112,6 @@ CONTAINS
       ! In the case of a cold restart, copy State_Chm into TrM with the
       ! appropriate units
       !------------------------------------------------------------------------
-
-      ! Convert to kg
-      CALL Convert_Spc_Units(                                                  &
-          Input_Opt  = Input_Opt,                                              &
-          State_Chm  = State_Chm,                                              &
-          State_Grid = State_Grid,                                             &
-          State_Met  = State_Met,                                              &
-          new_units  = KG_SPECIES,                                             &
-          RC         = RC                                                    )
-      IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
       DO N=1,NTM
          DO L=1,LM
             DO J=J_0,J_1
@@ -2223,16 +2179,6 @@ CONTAINS
          ENDDO
       ENDDO
     ENDIF
-
-    ! Convert to v/v dry
-    CALL Convert_Spc_Units(                                                    &
-         Input_Opt  = Input_Opt,                                               &
-         State_Chm  = State_Chm,                                               &
-         State_Grid = State_Grid,                                              &
-         State_Met  = State_Met,                                               &
-         new_units  = MOLES_SPECIES_PER_MOLES_DRY_AIR,                         &
-         RC         = RC                                                    )
-    IF ( RC /= GC_SUCCESS ) CALL STOP_MODEL( "Convert_Spc_Units", 255 )
 
     ! Return success
     RC = GC_SUCCESS

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -103,7 +103,6 @@ CONTAINS
     USE DOMAIN_DECOMP_ATM, ONLY : AM_I_ROOT, GRID, getDomainBounds, hasnorthpole, hassouthpole
     USE DOMAIN_DECOMP_1D,  ONLY : HALO_UPDATE, SOUTH, NORTH
     USE MODEL_COM,         ONLY : modelEclock, itime, ItimeI, DTsrc
-    ! USE MODELE_DRV,        ONLY : coldRestart
     USE ATM_COM,           ONLY : pedn, pmid, pk, ptropo, zatmo, mws, t, q, ualij, valij, qci, qcl
 #ifdef CALC_MERRA2_LIKE_DIAGS
     USE CLOUDS_COM,        ONLY : tauss, taumc, cldmc, cldss, cldss3d, pficu, pflcu, pfilsan, pfllsan

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -2387,7 +2387,7 @@ CONTAINS
     SpcInfo     => NULL()
 
     ! Name of this routine
-    LOC = ' -> at Get_GC_Restart (in GeosCore/hco_utilities_gc_mod.F90)'
+    LOC = ' -> at Get_GC_Restart (in model/CHEM_DRV.F90)'
 
     ! Set minimum value threshold for [mol/mol]
     SMALL_NUM = 1.0e-30_fp

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -103,6 +103,7 @@ CONTAINS
     USE DOMAIN_DECOMP_ATM, ONLY : AM_I_ROOT, GRID, getDomainBounds, hasnorthpole, hassouthpole
     USE DOMAIN_DECOMP_1D,  ONLY : HALO_UPDATE, SOUTH, NORTH
     USE MODEL_COM,         ONLY : modelEclock, itime, ItimeI, DTsrc
+    ! USE MODELE_DRV,        ONLY : coldRestart
     USE ATM_COM,           ONLY : pedn, pmid, pk, ptropo, zatmo, mws, t, q, ualij, valij, qci, qcl
 #ifdef CALC_MERRA2_LIKE_DIAGS
     USE CLOUDS_COM,        ONLY : tauss, taumc, cldmc, cldss, cldss3d, pficu, pflcu, pfilsan, pfllsan
@@ -1420,7 +1421,7 @@ CONTAINS
 
   !==========================================================================================================
 
-  SUBROUTINE INIT_CHEM( grid )
+  SUBROUTINE INIT_CHEM( grid, is_coldstart )
 
     USE DOMAIN_DECOMP_1D,        ONLY : getMpiCommunicator 
     USE DOMAIN_DECOMP_ATM,       ONLY : DIST_GRID, Am_I_Root, getDomainBounds
@@ -1455,9 +1456,12 @@ CONTAINS
     USE Photolysis_Mod,          ONLY : Init_Photolysis
     USE Vdiff_Mod,               ONLY : Max_PblHt_for_Vdiff
 
+    USE pario,                   ONLY : par_open, par_close
+
     IMPLICIT NONE
 
     TYPE (DIST_GRID), INTENT(IN) :: grid
+    LOGICAL, INTENT(IN)          :: is_coldstart
 
     LOGICAL   :: isRoot, prtDebug, TimeForEmis
     INTEGER   :: RC, previous_units
@@ -1470,6 +1474,8 @@ CONTAINS
     INTEGER   :: id_H2O, id_CH4, id_CLOCK
 
     INTEGER   :: TAU, TAUb
+
+    INTEGER   :: fid
 
     CHARACTER(LEN=255)       :: ThisLoc, historyConfigFile
     CHARACTER(LEN=512)       :: ErrMsg, Instr
@@ -2005,18 +2011,25 @@ CONTAINS
        CALL Error_Stop( ErrMsg, ThisLoc, Instr )
     ENDIF
 
-    CALL Get_GC_Restart( Input_Opt, State_Chm, State_Grid, &
-         State_Met, RC )    
+    IF (is_coldstart) THEN
+      ! In the case of a cold restart, initialise GEOS-Chem from its restart file
+      CALL Get_GC_Restart( Input_Opt, State_Chm, State_Grid, State_Met, RC )
 
-    !IF ( AM_I_ROOT() ) THEN
-    !   WRITE(6,*) State_Chm%Species(182)%Conc(1,:,1)
-    !ENDIF
- 
-    ! Trap potential errors
-    IF ( RC /= GC_SUCCESS ) THEN
-       ErrMsg = 'Error encountered in "Get_GC_Restart"'
-       Instr  = ''
-       CALL Error_Stop( ErrMsg, ThisLoc, Instr )
+      ! IF ( AM_I_ROOT() ) THEN
+      !   WRITE(6,*) State_Chm%Species(182)%Conc(1,:,1)
+      ! ENDIF
+  
+      ! Trap potential errors
+      IF ( RC /= GC_SUCCESS ) THEN
+        ErrMsg = 'Error encountered in "Get_GC_Restart"'
+        Instr  = ''
+        CALL Error_Stop( ErrMsg, ThisLoc, Instr )
+      ENDIF
+    ELSE
+      ! In the case of a non-cold-restart, initialise GEOS-Chem from the Model E restart file
+      fid = par_open( grid, trim( 'checkpoint.nc' ), 'read' )
+      CALL IO_CHEM(fid, 'read' )
+      call par_close( grid, fid )
     ENDIF
 
     IF ( Input_Opt%useTimers ) THEN

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -2130,6 +2130,18 @@ CONTAINS
       fid = par_open( grid, trim( 'fort.2.nc' ), 'read' )
       CALL IO_CHEM(fid, 'read' )
       call par_close( grid, fid )
+      ! TODO: More logic from Get_GC_Restart?
+      DO N=1,NTM
+         DO L=1,LM
+            DO J=J_0,J_1
+               DO I=I_0,I_1
+                  II = I - I_0 + 1
+                  JJ = J - J_0 + 1
+                  State_Chm%Species(N)%Conc(II,JJ,L) = TrM( I, J, L, N )
+               ENDDO
+            ENDDO
+         ENDDO
+      ENDDO
     ENDIF
 
     ! Return success

--- a/model/MODELE.f
+++ b/model/MODELE.f
@@ -236,7 +236,7 @@ C****
       call parse_params(iu_IFILE)
       call closeunit(iu_IFILE)
 
-      call initializeModelE()
+      call initializeModelE(coldRestart)
 
       ! Only the root node pays attention to allotted wall time
       if (AM_I_ROOT()) then
@@ -546,13 +546,15 @@ C**** RUN TERMINATED BECAUSE IT REACHED TAUE (OR SS6 WAS TURNED ON)
 
       contains
 
-      subroutine initializeModelE()
+      subroutine initializeModelE(is_coldstart)
       USE DOMAIN_DECOMP_1D, ONLY : init_app, am_i_root
       use Model_com, only: orbit, calendar, makeOrbit
       use Dictionary_mod
       USE MODEL_COM, only : master_yr
       use AbstractOrbit_mod, only: AbstractOrbit
       implicit none
+
+      LOGICAL, INTENT(IN) :: is_coldstart
 
       call initializeSysTimers()
 
@@ -577,7 +579,7 @@ C**** RUN TERMINATED BECAUSE IT REACHED TAUE (OR SS6 WAS TURNED ON)
 
       if (am_i_root()) call calendar%print(2000)
 
-      call alloc_drv_atm()
+      call alloc_drv_atm(is_coldstart)
       call alloc_drv_ocean()
 
       end subroutine initializeModelE


### PR DESCRIPTION
Closes #79.
Supersedes #87.

This PR sets up the infrastructure for having GEOS-Chem initialise tracers from a cold restart file generated by the GISS Model (except for when running in cold restart mode, whereby it's initialised from the GEOS-Chem restart file as usual).