### PR TITLE
Hook up other SUBDD-State_Diag for 3D `StateMet` tracers

### DIFF
--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -4222,17 +4222,17 @@ arr(next()) = info_type_(                        &
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_CLDF',                  &
-       lname = 'StateMet_CLDF',                  &
-       units = '1'                               &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_CLDF',                    &
+     lname = 'StateMet_CLDF',                    &
+     units = '1'                                 &
+     )
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_CMFMC',                 &
-       lname = 'StateMet_CMFMC',                 &
-       units = ''                                &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_CMFMC',                   &
+     lname = 'StateMet_CMFMC',                   &
+     units = ''                                  &
+     ) ! TODO: Units?
 
 #endif
 
@@ -4250,133 +4250,133 @@ arr(next()) = info_type_(                        &
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_DQRCU',                 &
-       lname = 'StateMet_DQRCU',                 &
-       units = 'kg / kg / s'                     &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_DQRCU',                   &
+     lname = 'StateMet_DQRCU',                   &
+     units = 'kg / kg / s'                       &
+     )
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_DQRLSAN',               &
-       lname = 'StateMet_DQRLSAN',               &
-       units = ''                                &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_DQRLSAN',                 &
+     lname = 'StateMet_DQRLSAN',                 &
+     units = ''                                  &
+     ) ! TODO: Units?
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_DTRAIN',                &
-       lname = 'StateMet_DTRAIN',                &
-       units = 'kg / m2 / s'                     &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_DTRAIN',                  &
+     lname = 'StateMet_DTRAIN',                  &
+     units = 'kg / m2 / s'                       &
+     )
 
 #endif
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_OMEGA',                 &
-       lname = 'StateMet_OMEGA',                 &
-       units = 'Pa s-1'                          &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_OMEGA',                   &
+     lname = 'StateMet_OMEGA',                   &
+     units = 'Pa s-1'                            &
+     )
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_OPTD',                  &
-       lname = 'StateMet_OPTD',                  &
-       units = '1'                               &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_OPTD',                    &
+     lname = 'StateMet_OPTD',                    &
+     units = '1'                                 &
+     )
 
 #endif
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_PEDGE',                 &
-       lname = 'StateMet_PEDGE',                 &
-       units = ''                                &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_PEDGE',                   &
+     lname = 'StateMet_PEDGE',                   &
+     units = ''                                  &
+     ) ! TODO: Units?
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_PFICU',                 &
-       lname = 'StateMet_PFICU',                 &
-       units = ''                                &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_PFICU',                   &
+     lname = 'StateMet_PFICU',                   &
+     units = ''                                  &
+     ) ! TODO: Units?
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_PFILSAN',               &
-       lname = 'StateMet_PFILSAN',               &
-       units = ''                                &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_PFILSAN',                 &
+     lname = 'StateMet_PFILSAN',                 &
+     units = ''                                  &
+     ) ! TODO: Units?
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_PFLCU',                 &
-       lname = 'StateMet_PFLCU',                 &
-       units = ''                                &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_PFLCU',                   &
+     lname = 'StateMet_PFLCU',                   &
+     units = ''                                  &
+     ) ! TODO: Units?
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_PFLLSAN',               &
-       lname = 'StateMet_PFLLSAN',               &
-       units = ''                                &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_PFLLSAN',                 &
+     lname = 'StateMet_PFLLSAN',                 &
+     units = ''                                  &
+     ) ! TODO: Units?
 
 #endif
 
-  arr(next()) = info_type_(                       &
-       sname = 'StateMet_QI',                     &
-       lname = 'StateMet_QI',                     &
-       units = 'kg / kg'                          &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_QI',                      &
+     lname = 'StateMet_QI',                      &
+     units = 'kg / kg'                           &
+     )
 
-  arr(next()) = info_type_(                       &
-       sname = 'StateMet_QL',                     &
-       lname = 'StateMet_QL',                     &
-       units = 'kg / kg'                          &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_QL',                      &
+     lname = 'StateMet_QL',                      &
+     units = 'kg / kg'                           &
+     )
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
-  arr(next()) = info_type_(                       &
-       sname = 'StateMet_REEVAPCN',               &
-       lname = 'StateMet_REEVAPCN',               &
-       units = 'kg / kg / s'                      &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_REEVAPCN',                &
+     lname = 'StateMet_REEVAPCN',                &
+     units = 'kg / kg / s'                       &
+     )
 
-  arr(next()) = info_type_(                       &
-       sname = 'StateMet_REEVAPLS',               &
-       lname = 'StateMet_REEVAPLS',               &
-       units = 'kg / kg / s'                      &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_REEVAPLS',                &
+     lname = 'StateMet_REEVAPLS',                &
+     units = 'kg / kg / s'                       &
+     )
 
 #endif
 
-  arr(next()) = info_type_(                       &
-       sname = 'StateMet_RH',                     &
-       lname = 'StateMet_RH',                     &
-       units = ''                                 &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_RH',                      &
+     lname = 'StateMet_RH',                      &
+     units = ''                                  &
+     )
 
-  arr(next()) = info_type_(                       &
-       sname = 'StateMet_SPHU',                   &
-       lname = 'StateMet_SPHU',                   &
-       units = 'g H2O / kg air'                   &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_SPHU',                    &
+     lname = 'StateMet_SPHU',                    &
+     units = 'g H2O / kg air'                    &
+     )
 
-  arr(next()) = info_type_(                       &
-       sname = 'StateMet_SPHU1',                  &
-       lname = 'StateMet_SPHU1',                  &
-       units = 'kg / kg'                          &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_SPHU1',                   &
+     lname = 'StateMet_SPHU1',                   &
+     units = 'kg / kg'                           &
+     )
 
-  arr(next()) = info_type_(                       &
-       sname = 'StateMet_SPHU2',                  &
-       lname = 'StateMet_SPHU2',                  &
-       units = 'kg / kg'                          &
-       )
-       
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_T',                     &
-       lname = 'StateMet_T',                     &
-       units = 'K'                               &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_SPHU2',                   &
+     lname = 'StateMet_SPHU2',                   &
+     units = 'kg / kg'                           &
+     )
+
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_T',                       &
+     lname = 'StateMet_T',                       &
+     units = 'K'                                 &
+     )
 
 arr(next()) = info_type_(                        &
     sname = 'StateMet_THETA',                    &
@@ -4386,53 +4386,53 @@ arr(next()) = info_type_(                        &
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_TAUCLI',                &
-       lname = 'StateMet_TAUCLI',                &
-       units = '1'                               &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_TAUCLI',                  &
+     lname = 'StateMet_TAUCLI',                  &
+     units = '1'                                 &
+     )
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_TAUCLW',                &
-       lname = 'StateMet_TAUCLW',                &
-       units = '1'                               &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_TAUCLW',                  &
+     lname = 'StateMet_TAUCLW',                  &
+     units = '1'                                 &
+     )
 
 #endif
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_TMPU1',                 &
-       lname = 'StateMet_TMPU1',                 &
-       units = 'K'                               &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_TMPU1',                   &
+     lname = 'StateMet_TMPU1',                   &
+     units = 'K'                                 &
+     )
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_TMPU2',                 &
-       lname = 'StateMet_TMPU2',                 &
-       units = 'K'                               &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_TMPU2',                   &
+     lname = 'StateMet_TMPU2',                   &
+     units = 'K'                                 &
+     )
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_U',                     &
-       lname = 'StateMet_U',                     &
-       units = 'm / s'                           &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_U',                       &
+     lname = 'StateMet_U',                       &
+     units = 'm / s'                             &
+     )
 
 #ifdef MODEL_GEOS
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_UPDVVEL',               &
-       lname = 'StateMet_UPDVVEL',               &
-       units = ''                                &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_UPDVVEL',                 &
+     lname = 'StateMet_UPDVVEL',                 &
+     units = ''                                  &
+     ) ! TODO: Units?
 
 #endif
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_V',                     &
-       lname = 'StateMet_V',                     &
-       units = 'm / s'                           &
-       )
+arr(next()) = info_type_(                        &
+     sname = 'StateMet_V',                       &
+     lname = 'StateMet_V',                       &
+     units = 'm / s'                             &
+     )
 
 return
 contains

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -438,10 +438,19 @@ CONTAINS
              if(hassouthpole(grid) .and. JJJ .eq. J_0 ) I = 1
              if(hasnorthpole(grid) .and. JJJ .eq. J_1 ) I = 1
 
+             ! Dry air mass [kg]
              ! TODO: State_Met%AD          (II,JJ,K) = ???
+
+             ! Dry air density [kg m-3]
              ! TODO: State_Met%AIRDEN      (II,JJ,K) = ???
+
+             ! Volume of grid box [m3]
              ! TODO: State_Met%AIRVOL      (II,JJ,K) = ???
+
+             ! Water vapor mixing ratio (w/r/t dry air)
              ! TODO: State_Met%AVGW        (II,JJ,K) = ???
+
+             ! Grid box height [m]
              ! TODO: State_Met%BXHEIGHT    (II,JJ,K) = ???
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
@@ -453,7 +462,10 @@ CONTAINS
 
 #endif
 
+             ! Delta-pressure across grid box(wet air) [hPa]
              ! TODO: State_Met%DELP        (II,JJ,K) = ???
+
+             ! Delta-pressure across grid box (dry air) [hPa]
              ! TODO: State_Met%DELPDRY     (II,JJ,K) = ???
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
@@ -529,6 +541,7 @@ CONTAINS
              ! Temperature [K]
              State_Met%T           (II,JJ,K) = t(i,j,k)*pk(k,i,j)
 
+             ! Potential temperature [K]
              ! TODO: State_Met%THETA       (II,JJ,K) = ???
 
 #ifdef CALC_MERRA2_LIKE_DIAGS

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -2287,66 +2287,75 @@ CONTAINS
                 ENDDO
                 ENDDO
                 ENDDO
+                call inc_subdd(subdd,k,sddarr3d)
+                exit ntm_loop
+             end if
+          end do ntm_loop
+       enddo ! k
+    enddo ! igroup
 
-                if ( trim(subdd%name(k)) == "StateMet_AD" ) then
-                  DO L=1,LmaxSUBDD
-                  DO J=J_0,J_1
-                  DO I=I_0,I_1
-                      II = I - I_0 + 1
-                      JJ = J - J_0 + 1
-                      sddarr3d(I,J,L) = State_Met%AD(II,JJ,L)
-                  ENDDO
-                  ENDDO
-                  ENDDO
-                endif
+    do igrp=1,ngroups
+       subdd => subdd_groups(grpids(igrp))
+       do k=1,subdd%ndiags
+          if ( trim(subdd%name(k)) == "StateMet_AD" ) then
+            DO L=1,LmaxSUBDD
+            DO J=J_0,J_1
+            DO I=I_0,I_1
+                II = I - I_0 + 1
+                JJ = J - J_0 + 1
+                sddarr3d(I,J,L) = State_Met%AD(II,JJ,L)
+            ENDDO
+            ENDDO
+            ENDDO
+          endif
 
-                if ( trim(subdd%name(k)) == "StateMet_AIRDEN" ) then
-                  DO L=1,LmaxSUBDD
-                  DO J=J_0,J_1
-                  DO I=I_0,I_1
-                      II = I - I_0 + 1
-                      JJ = J - J_0 + 1
-                      sddarr3d(I,J,L) = State_Met%AIRDEN(II,JJ,L)
-                  ENDDO
-                  ENDDO
-                  ENDDO
-                endif
+          if ( trim(subdd%name(k)) == "StateMet_AIRDEN" ) then
+            DO L=1,LmaxSUBDD
+            DO J=J_0,J_1
+            DO I=I_0,I_1
+                II = I - I_0 + 1
+                JJ = J - J_0 + 1
+                sddarr3d(I,J,L) = State_Met%AIRDEN(II,JJ,L)
+            ENDDO
+            ENDDO
+            ENDDO
+          endif
 
-                if ( trim(subdd%name(k)) == "StateMet_AIRVOL" ) then
-                  DO L=1,LmaxSUBDD
-                  DO J=J_0,J_1
-                  DO I=I_0,I_1
-                      II = I - I_0 + 1
-                      JJ = J - J_0 + 1
-                      sddarr3d(I,J,L) = State_Met%AIRVOL(II,JJ,L)
-                  ENDDO
-                  ENDDO
-                  ENDDO
-                endif
+          if ( trim(subdd%name(k)) == "StateMet_AIRVOL" ) then
+            DO L=1,LmaxSUBDD
+            DO J=J_0,J_1
+            DO I=I_0,I_1
+                II = I - I_0 + 1
+                JJ = J - J_0 + 1
+                sddarr3d(I,J,L) = State_Met%AIRVOL(II,JJ,L)
+            ENDDO
+            ENDDO
+            ENDDO
+          endif
 
-                if ( trim(subdd%name(k)) == "StateMet_AVGW" ) then
-                  DO L=1,LmaxSUBDD
-                  DO J=J_0,J_1
-                  DO I=I_0,I_1
-                      II = I - I_0 + 1
-                      JJ = J - J_0 + 1
-                      sddarr3d(I,J,L) = State_Met%AVGW(II,JJ,L)
-                  ENDDO
-                  ENDDO
-                  ENDDO
-                endif
+          if ( trim(subdd%name(k)) == "StateMet_AVGW" ) then
+            DO L=1,LmaxSUBDD
+            DO J=J_0,J_1
+            DO I=I_0,I_1
+                II = I - I_0 + 1
+                JJ = J - J_0 + 1
+                sddarr3d(I,J,L) = State_Met%AVGW(II,JJ,L)
+            ENDDO
+            ENDDO
+            ENDDO
+          endif
 
-                if ( trim(subdd%name(k)) == "StateMet_BXHEIGHT" ) then
-                  DO L=1,LmaxSUBDD
-                  DO J=J_0,J_1
-                  DO I=I_0,I_1
-                      II = I - I_0 + 1
-                      JJ = J - J_0 + 1
-                      sddarr3d(I,J,L) = State_Met%BXHEIGHT(II,JJ,L)
-                  ENDDO
-                  ENDDO
-                  ENDDO
-                endif
+          if ( trim(subdd%name(k)) == "StateMet_BXHEIGHT" ) then
+            DO L=1,LmaxSUBDD
+            DO J=J_0,J_1
+            DO I=I_0,I_1
+                II = I - I_0 + 1
+                JJ = J - J_0 + 1
+                sddarr3d(I,J,L) = State_Met%BXHEIGHT(II,JJ,L)
+            ENDDO
+            ENDDO
+            ENDDO
+          endif
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
@@ -2376,29 +2385,29 @@ CONTAINS
 
 #endif
 
-                if ( trim(subdd%name(k)) == "StateMet_DELP" ) then
-                  DO L=1,LmaxSUBDD
-                  DO J=J_0,J_1
-                  DO I=I_0,I_1
-                      II = I - I_0 + 1
-                      JJ = J - J_0 + 1
-                      sddarr3d(I,J,L) = State_Met%DELP(II,JJ,L)
-                  ENDDO
-                  ENDDO
-                  ENDDO
-                endif
+          if ( trim(subdd%name(k)) == "StateMet_DELP" ) then
+            DO L=1,LmaxSUBDD
+            DO J=J_0,J_1
+            DO I=I_0,I_1
+                II = I - I_0 + 1
+                JJ = J - J_0 + 1
+                sddarr3d(I,J,L) = State_Met%DELP(II,JJ,L)
+            ENDDO
+            ENDDO
+            ENDDO
+          endif
 
-                if ( trim(subdd%name(k)) == "StateMet_DELPDRY" ) then
-                  DO L=1,LmaxSUBDD
-                  DO J=J_0,J_1
-                  DO I=I_0,I_1
-                      II = I - I_0 + 1
-                      JJ = J - J_0 + 1
-                      sddarr3d(I,J,L) = State_Met%DELP_DRY(II,JJ,L)
-                  ENDDO
-                  ENDDO
-                  ENDDO
-                endif
+          if ( trim(subdd%name(k)) == "StateMet_DELPDRY" ) then
+            DO L=1,LmaxSUBDD
+            DO J=J_0,J_1
+            DO I=I_0,I_1
+                II = I - I_0 + 1
+                JJ = J - J_0 + 1
+                sddarr3d(I,J,L) = State_Met%DELP_DRY(II,JJ,L)
+            ENDDO
+            ENDDO
+            ENDDO
+          endif
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
@@ -2644,17 +2653,17 @@ CONTAINS
              ENDDO
           endif
 
-                if ( trim(subdd%name(k)) == "StateMet_THETA" ) then
-                  DO L=1,LmaxSUBDD
-                  DO J=J_0,J_1
-                  DO I=I_0,I_1
-                      II = I - I_0 + 1
-                      JJ = J - J_0 + 1
-                      sddarr3d(I,J,L) = State_Met%THETA(II,JJ,L)
-                  ENDDO
-                  ENDDO
-                  ENDDO
-                endif
+          if ( trim(subdd%name(k)) == "StateMet_THETA" ) then
+            DO L=1,LmaxSUBDD
+            DO J=J_0,J_1
+            DO I=I_0,I_1
+                II = I - I_0 + 1
+                JJ = J - J_0 + 1
+                sddarr3d(I,J,L) = State_Met%THETA(II,JJ,L)
+            ENDDO
+            ENDDO
+            ENDDO
+          endif
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
@@ -2748,10 +2757,7 @@ CONTAINS
              ENDDO
           endif
 
-                call inc_subdd(subdd,k,sddarr3d)
-                exit ntm_loop
-             end if
-          end do ntm_loop
+          call inc_subdd(subdd,k,sddarr3d)
        enddo ! k
     enddo ! igroup
 

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -438,99 +438,115 @@ CONTAINS
              if(hassouthpole(grid) .and. JJJ .eq. J_0 ) I = 1
              if(hasnorthpole(grid) .and. JJJ .eq. J_1 ) I = 1
 
+             ! TODO: State_Met%AD          (II,JJ,K) = ???
+             ! TODO: State_Met%AIRDEN      (II,JJ,K) = ???
+             ! TODO: State_Met%AIRVOL      (II,JJ,K) = ???
+             ! TODO: State_Met%AVGW        (II,JJ,K) = ???
+             ! TODO: State_Met%BXHEIGHT    (II,JJ,K) = ???
+
 #ifdef CALC_MERRA2_LIKE_DIAGS
              ! 3-D cloud fraction [1]
-             State_Met%CLDF        (II,JJ,K) = min(1.0,CLDSS3D(k,i,j) + CLDMC(k,i,j))                   
+             State_Met%CLDF        (II,JJ,K) = min(1.0,CLDSS3D(k,i,j) + CLDMC(k,i,j))
 
              ! Cloud mass flux [kg/m2/s]
-             State_Met%CMFMC       (II,JJ,K) = cmfmc(i,j,k)                                             
+             State_Met%CMFMC       (II,JJ,K) = cmfmc(i,j,k)
+
+#endif
+
+             ! TODO: State_Met%DELP        (II,JJ,K) = ???
+             ! TODO: State_Met%DELPDRY     (II,JJ,K) = ???
+
+#ifdef CALC_MERRA2_LIKE_DIAGS
 
              ! Conv precip production rate [kg/kg/s] (assume per dry air)
-             State_Met%DQRCU       (II,JJ,K) = dqrcu(i,j,k)                                             
+             State_Met%DQRCU       (II,JJ,K) = dqrcu(i,j,k)
 
              ! LS precip prod rate [kg/kg/s] (assume per dry air)
-             State_Met%DQRLSAN     (II,JJ,K) = dqrlsan(i,j,k)                                           
+             State_Met%DQRLSAN     (II,JJ,K) = dqrlsan(i,j,k)
 
              ! Detrainment flux [kg/m2/s]
-             State_Met%DTRAIN      (II,JJ,K) = dtrain(i,j,k)                                            
+             State_Met%DTRAIN      (II,JJ,K) = dtrain(i,j,k)
+
 #endif
 
              ! Vertical pressure velocity [Pa/s]
-             State_Met%OMEGA       (II,JJ,K) = MWs(i,j,k)*byaxyp(i,j)*100.0/dtsrc                       
+             State_Met%OMEGA       (II,JJ,K) = MWs(i,j,k)*byaxyp(i,j)*100.0/dtsrc
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
              ! Visible optical depth [1]
-             State_Met%OPTD        (II,JJ,K) = (cldss(k,i,j)*TAUSS(k,i,j) + &                           
+             State_Met%OPTD        (II,JJ,K) = (cldss(k,i,j)*TAUSS(k,i,j) + &
                   cldmc(k,i,j)*TAUMC(k,i,j)  ) / ( cldss(k,i,j) + cldmc(k,i,j) + teeny )
 #endif
 
              ! Wet air press @ level edges [hPa]
-             State_Met%PEDGE       (II,JJ,K) = pedn(k,i,j)                                              
+             State_Met%PEDGE       (II,JJ,K) = pedn(k,i,j)
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
              ! Dwn flux ice prec:conv [kg/m2/s]
-             State_Met%PFICU       (II,JJ,K) = pficu(i,j,k)                                             
+             State_Met%PFICU       (II,JJ,K) = pficu(i,j,k)
 
              ! Dwn flux ice prec:LS+anv [kg/m2/s]
-             State_Met%PFILSAN     (II,JJ,K) = pfilsan(i,j,k)                                           
+             State_Met%PFILSAN     (II,JJ,K) = pfilsan(i,j,k)
 
              ! Dwn flux liq prec:conv [kg/m2/s]
-             State_Met%PFLCU       (II,JJ,K) = pflcu(i,j,k)                                             
+             State_Met%PFLCU       (II,JJ,K) = pflcu(i,j,k)
 
              ! Dwn flux ice prec:LS+anv [kg/m2/s]
-             State_Met%PFLLSAN     (II,JJ,K) = pfllsan(i,j,k)                                           
+             State_Met%PFLLSAN     (II,JJ,K) = pfllsan(i,j,k)
 #endif
 
              ! Ice mixing ratio [kg/kg dry air]
-             State_Met%QI          (II,JJ,K) = qci(i,j,k)                                               
+             State_Met%QI          (II,JJ,K) = qci(i,j,k)
 
              ! Water mixing ratio [kg/kg dry air]
-             State_Met%QL          (II,JJ,K) = qcl(i,j,k)                                               
+             State_Met%QL          (II,JJ,K) = qcl(i,j,k)
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
              ! Evap of precip conv [kg/kg/s] (assume per dry air)
-             State_Met%REEVAPCN    (II,JJ,K) = reevapcn(i,j,k)                                          
+             State_Met%REEVAPCN    (II,JJ,K) = reevapcn(i,j,k)
 
              ! Evap of precip LS+anvil [kg/kg/s] (assume per dry air)
-             State_Met%REEVAPLS    (II,JJ,K) = reevapls(i,j,k)                                          
+             State_Met%REEVAPLS    (II,JJ,K) = reevapls(i,j,k)
 #endif
 
              ! Relative humidity [%]
              State_Met%RH          (II,JJ,K) = 100.*q(i,j,k)/QSAT(t(i,j,k)*pk(k,i,j),LHE,pmid(k,i,j))   
              IF ( IT_IS_NAN( State_Met%RH(II,JJ,K) ) ) THEN
                 WRITE(6,*) II,JJ,K, q(i,j,k), QSAT(t(i,j,k)*pk(k,i,j),LHE,pmid(k,i,j)), &
-                     t(i,j,k), pk(k,i,j), LHE, pmid(k,i,j)               
+                     t(i,j,k), pk(k,i,j), LHE, pmid(k,i,j)
                 CALL STOP_MODEL("Bad RH",255)
              ENDIF
 
              ! Specific humidity [g H2O/kg tot air]
-             State_Met%SPHU        (II,JJ,K) = q(i,j,k)                                                 
+             State_Met%SPHU        (II,JJ,K) = q(i,j,k)
 
              ! Specific humidity at start of timestep [g/kg]
-             State_Met%SPHU1       (II,JJ,K) = q(i,j,k)                                                 
+             State_Met%SPHU1       (II,JJ,K) = q(i,j,k)
 
              ! Specific humidity at end of timestep [g/kg]  
-             State_Met%SPHU2       (II,JJ,K) = q(i,j,k)                                                 
+             State_Met%SPHU2       (II,JJ,K) = q(i,j,k)
 
              ! Temperature [K]
-             State_Met%T           (II,JJ,K) = t(i,j,k)*pk(k,i,j)                                       
+             State_Met%T           (II,JJ,K) = t(i,j,k)*pk(k,i,j)
+
+             ! TODO: State_Met%THETA       (II,JJ,K) = ???
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
              ! Optical depth of ice clouds [1]
-             State_Met%TAUCLI      (II,JJ,K) = taui3d(i,j,k)                                            
+             State_Met%TAUCLI      (II,JJ,K) = taui3d(i,j,k)
 
              ! Optical depth of H2O clouds [1]
              State_Met%TAUCLW      (II,JJ,K) = tauw3d(i,j,k)
 #endif
 
              ! Temperature at start of timestep [K]
-             State_Met%TMPU1       (II,JJ,K) = t(i,j,k)*pk(k,i,j)                                       
+             State_Met%TMPU1       (II,JJ,K) = t(i,j,k)*pk(k,i,j)
 
              ! Temperature at end of timestep [K]
-             State_Met%TMPU2       (II,JJ,K) = t(i,j,k)*pk(k,i,j)                                       
+             State_Met%TMPU2       (II,JJ,K) = t(i,j,k)*pk(k,i,j)
 
              ! E/W component of wind [m s-1]
-             State_Met%U           (II,JJ,K) = ualij(k,i,j)                                             
+             State_Met%U           (II,JJ,K) = ualij(k,i,j)
 
 #ifdef MODEL_GEOS
              ! Updraft vertical velocity [hPa/s] (only used by GEOS)
@@ -538,7 +554,7 @@ CONTAINS
 #endif
 
              ! N/S component of wind [m s-1]
-             State_Met%V           (II,JJ,K) = valij(k,i,j)                                             
+             State_Met%V           (II,JJ,K) = valij(k,i,j)
 
           ENDDO
        ENDDO
@@ -551,7 +567,7 @@ CONTAINS
           II = I - I_0 + 1
           JJ = J - J_0 + 1
 
-          State_Met%PEDGE       (II,JJ,LM+1) =  pedn(LM+1,i,j)                                    
+          State_Met%PEDGE       (II,JJ,LM+1) =  pedn(LM+1,i,j)
 #ifdef CALC_MERRA2_LIKE_DIAGS
           State_Met%CMFMC       (II,JJ,LM+1) =  cmfmc(i,j,LM+1)
           State_Met%PFICU       (II,JJ,LM+1) =  pficu(i,j,LM+1)
@@ -2259,9 +2275,14 @@ CONTAINS
                 ENDDO
                 ENDDO
 
+                ! TODO: State_Met%AD
+                ! TODO: State_Met%AIRDEN
+                ! TODO: State_Met%AIRVOL
+                ! TODO: State_Met%AVGW
+                ! TODO: State_Met%BXHEIGHT
+
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
-          
           if ( trim(subdd%name(k)) == "StateMet_CLDF" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2273,7 +2294,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-                
+
           if ( trim(subdd%name(k)) == "StateMet_CMFMC" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2285,7 +2306,13 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-                
+
+#endif
+                ! TODO: State_Met%DELP
+                ! TODO: State_Met%DELPDRY
+
+#ifdef CALC_MERRA2_LIKE_DIAGS
+
           if ( trim(subdd%name(k)) == "StateMet_DQRCU" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2297,7 +2324,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-                
+
           if ( trim(subdd%name(k)) == "StateMet_DQRLSAN" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2309,7 +2336,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-                
+
           if ( trim(subdd%name(k)) == "StateMet_DTRAIN" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2324,7 +2351,6 @@ CONTAINS
 
 #endif
 
-               
           if ( trim(subdd%name(k)) == "StateMet_OMEGA" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2339,7 +2365,6 @@ CONTAINS
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
-                
           if ( trim(subdd%name(k)) == "StateMet_OPTD" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2354,7 +2379,6 @@ CONTAINS
 
 #endif
 
-               
           if ( trim(subdd%name(k)) == "StateMet_PEDGE" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2369,7 +2393,6 @@ CONTAINS
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
-               
           if ( trim(subdd%name(k)) == "StateMet_PFICU" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2381,7 +2404,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-                
+
           if ( trim(subdd%name(k)) == "StateMet_PFILSAN" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2393,7 +2416,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-                
+
           if ( trim(subdd%name(k)) == "StateMet_PFLCU" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2405,7 +2428,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-                
+
           if ( trim(subdd%name(k)) == "StateMet_PFLLSAN" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2420,7 +2443,6 @@ CONTAINS
 
 #endif
 
-           
           if ( trim(subdd%name(k)) == "StateMet_QI" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2432,7 +2454,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-                
+
           if ( trim(subdd%name(k)) == "StateMet_QL" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2458,7 +2480,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-                
+
           if ( trim(subdd%name(k)) == "StateMet_REEVAPLS" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2484,7 +2506,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-                
+
           if ( trim(subdd%name(k)) == "StateMet_SPHU" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2496,7 +2518,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-                
+
           if ( trim(subdd%name(k)) == "StateMet_SPHU1" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2508,7 +2530,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-               
+
           if ( trim(subdd%name(k)) == "StateMet_SPHU2" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2520,7 +2542,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-                
+
           if ( trim(subdd%name(k)) == "StateMet_T" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2533,9 +2555,10 @@ CONTAINS
              ENDDO
           endif
 
+                ! TODO: State_Met%THETA
+
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
-           
           if ( trim(subdd%name(k)) == "StateMet_TAUCLI" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2547,7 +2570,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-                
+
           if ( trim(subdd%name(k)) == "StateMet_TAUCLW" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2562,7 +2585,6 @@ CONTAINS
 
 #endif
 
-                
           if ( trim(subdd%name(k)) == "StateMet_TMPU1" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2574,7 +2596,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-               
+
           if ( trim(subdd%name(k)) == "StateMet_TMPU2" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -2586,7 +2608,7 @@ CONTAINS
              ENDDO
              ENDDO
           endif
-               
+
           if ( trim(subdd%name(k)) == "StateMet_U" ) then
              DO L=1,LmaxSUBDD
              DO J=J_0,J_1
@@ -4056,39 +4078,53 @@ decl_count = 0
 ! First, diagnostics available for all tracers:
 do n=1,nsp
    ! 3D mixing ratios (SUBDD string is just tracer name):
-   arr(next()) = info_type_(                      &
+   arr(next()) = info_type_(                     &
        sname = trim(spname(n)),                  &
        lname = trim(spname(n))//' mixing ratio', &
        units = 'mol mol-1'                       &
        )
+
 end do ! tracers loop
+
+       ! TODO: State_Met%AD
+       ! TODO: State_Met%AIRDEN
+       ! TODO: State_Met%AIRVOL
+       ! TODO: State_Met%AVGW
+       ! TODO: State_Met%BXHEIGHT
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
-  arr(next()) = info_type_(                     &
-       sname = 'StateMet_CLDF',                 &
-       lname = 'StateMet_CLDF',                 &
-       units = '1'                              &
-       )
-       
   arr(next()) = info_type_(                      &
-       sname = 'StateMet_CMFMC',                &
-       lname = 'StateMet_CMFMC',                &
-       units = ''                              &
+       sname = 'StateMet_CLDF',                  &
+       lname = 'StateMet_CLDF',                  &
+       units = '1'                               &
        )
-      
+
+  arr(next()) = info_type_(                      &
+       sname = 'StateMet_CMFMC',                 &
+       lname = 'StateMet_CMFMC',                 &
+       units = ''                                &
+       )
+
+#endif
+
+       ! TODO: State_Met%DELP
+       ! TODO: State_Met%DELPDRY
+
+#ifdef CALC_MERRA2_LIKE_DIAGS
+
   arr(next()) = info_type_(                      &
        sname = 'StateMet_DQRCU',                 &
        lname = 'StateMet_DQRCU',                 &
        units = 'kg / kg / s'                     &
        )
-  
-arr(next()) = info_type_(                        &
+
+  arr(next()) = info_type_(                      &
        sname = 'StateMet_DQRLSAN',               &
        lname = 'StateMet_DQRLSAN',               &
        units = ''                                &
        )
-      
+
   arr(next()) = info_type_(                      &
        sname = 'StateMet_DTRAIN',                &
        lname = 'StateMet_DTRAIN',                &
@@ -4097,7 +4133,6 @@ arr(next()) = info_type_(                        &
 
 #endif
 
-      
   arr(next()) = info_type_(                      &
        sname = 'StateMet_OMEGA',                 &
        lname = 'StateMet_OMEGA',                 &
@@ -4114,38 +4149,36 @@ arr(next()) = info_type_(                        &
 
 #endif
 
-       
   arr(next()) = info_type_(                      &
-       sname = 'StateMet_PEDGE',                &
-       lname = 'StateMet_PEDGE',                &
-       units = ''                              &
+       sname = 'StateMet_PEDGE',                 &
+       lname = 'StateMet_PEDGE',                 &
+       units = ''                                &
        )
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
-      
   arr(next()) = info_type_(                      &
-       sname = 'StateMet_PFICU',                &
-       lname = 'StateMet_PFICU',                &
-       units = ''                              &
+       sname = 'StateMet_PFICU',                 &
+       lname = 'StateMet_PFICU',                 &
+       units = ''                                &
        )
-       
+
   arr(next()) = info_type_(                      &
-       sname = 'StateMet_PFILSAN',                &
-       lname = 'StateMet_PFILSAN',                &
-       units = ''                              &
+       sname = 'StateMet_PFILSAN',               &
+       lname = 'StateMet_PFILSAN',               &
+       units = ''                                &
        )
-       
+
   arr(next()) = info_type_(                      &
-       sname = 'StateMet_PFLCU',                &
-       lname = 'StateMet_PFLCU',                &
-       units = ''                              &
+       sname = 'StateMet_PFLCU',                 &
+       lname = 'StateMet_PFLCU',                 &
+       units = ''                                &
        )
-       
+
   arr(next()) = info_type_(                      &
-       sname = 'StateMet_PFLLSAN',                &
-       lname = 'StateMet_PFLLSAN',                &
-       units = ''                              &
+       sname = 'StateMet_PFLLSAN',               &
+       lname = 'StateMet_PFLLSAN',               &
+       units = ''                                &
        )
 
 #endif
@@ -4153,9 +4186,9 @@ arr(next()) = info_type_(                        &
   arr(next()) = info_type_(                       &
        sname = 'StateMet_QI',                     &
        lname = 'StateMet_QI',                     &
-       units = 'kg / kg'                          &     
+       units = 'kg / kg'                          &
        )
-       
+
   arr(next()) = info_type_(                       &
        sname = 'StateMet_QL',                     &
        lname = 'StateMet_QL',                     &
@@ -4169,7 +4202,7 @@ arr(next()) = info_type_(                        &
        lname = 'StateMet_REEVAPCN',               &
        units = 'kg / kg / s'                      &
        )
-       
+
   arr(next()) = info_type_(                       &
        sname = 'StateMet_REEVAPLS',               &
        lname = 'StateMet_REEVAPLS',               &
@@ -4178,28 +4211,28 @@ arr(next()) = info_type_(                        &
 
 #endif
 
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_RH',                &
-       lname = 'StateMet_RH',                &
-       units = ''                              &
+  arr(next()) = info_type_(                       &
+       sname = 'StateMet_RH',                     &
+       lname = 'StateMet_RH',                     &
+       units = ''                                 &
        )
-      
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_SPHU',                  &
-       lname = 'StateMet_SPHU',                  &
-       units = 'g H2O / kg air'                  &
+
+  arr(next()) = info_type_(                       &
+       sname = 'StateMet_SPHU',                   &
+       lname = 'StateMet_SPHU',                   &
+       units = 'g H2O / kg air'                   &
        )
-       
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_SPHU1',                 &
-       lname = 'StateMet_SPHU1',                 &
-       units = 'kg / kg'                         &
+
+  arr(next()) = info_type_(                       &
+       sname = 'StateMet_SPHU1',                  &
+       lname = 'StateMet_SPHU1',                  &
+       units = 'kg / kg'                          &
        )
-       
-  arr(next()) = info_type_(                      &
-       sname = 'StateMet_SPHU2',                 &
-       lname = 'StateMet_SPHU2',                 &
-       units = 'kg / kg'                         &
+
+  arr(next()) = info_type_(                       &
+       sname = 'StateMet_SPHU2',                  &
+       lname = 'StateMet_SPHU2',                  &
+       units = 'kg / kg'                          &
        )
        
   arr(next()) = info_type_(                      &
@@ -4208,6 +4241,8 @@ arr(next()) = info_type_(                        &
        units = 'K'                               &
        )
 
+       ! TODO: State_Met%THETA
+
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
   arr(next()) = info_type_(                      &
@@ -4215,7 +4250,7 @@ arr(next()) = info_type_(                        &
        lname = 'StateMet_TAUCLI',                &
        units = '1'                               &
        )
-      
+
   arr(next()) = info_type_(                      &
        sname = 'StateMet_TAUCLW',                &
        lname = 'StateMet_TAUCLW',                &
@@ -4229,13 +4264,13 @@ arr(next()) = info_type_(                        &
        lname = 'StateMet_TMPU1',                 &
        units = 'K'                               &
        )
-       
+
   arr(next()) = info_type_(                      &
        sname = 'StateMet_TMPU2',                 &
        lname = 'StateMet_TMPU2',                 &
        units = 'K'                               &
        )
-       
+
   arr(next()) = info_type_(                      &
        sname = 'StateMet_U',                     &
        lname = 'StateMet_U',                     &
@@ -4245,9 +4280,9 @@ arr(next()) = info_type_(                        &
 #ifdef MODEL_GEOS
 
   arr(next()) = info_type_(                      &
-       sname = 'StateMet_UPDVVEL',                &
-       lname = 'StateMet_UPDVVEL',                &
-       units = ''                              &
+       sname = 'StateMet_UPDVVEL',               &
+       lname = 'StateMet_UPDVVEL',               &
+       units = ''                                &
        )
 
 #endif
@@ -4257,8 +4292,6 @@ arr(next()) = info_type_(                        &
        lname = 'StateMet_V',                     &
        units = 'm / s'                           &
        )
-
-
 
 return
 contains

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -4231,8 +4231,8 @@ arr(next()) = info_type_(                        &
 arr(next()) = info_type_(                        &
      sname = 'StateMet_CMFMC',                   &
      lname = 'StateMet_CMFMC',                   &
-     units = ''                                  &
-     ) ! TODO: Units?
+     units = 'kg m-2 s-1'                        &
+     )
 
 #endif
 
@@ -4253,14 +4253,14 @@ arr(next()) = info_type_(                        &
 arr(next()) = info_type_(                        &
      sname = 'StateMet_DQRCU',                   &
      lname = 'StateMet_DQRCU',                   &
-     units = 'kg / kg / s'                       &
+     units = 'kg kg-1 s-1'                       &
      )
 
 arr(next()) = info_type_(                        &
      sname = 'StateMet_DQRLSAN',                 &
      lname = 'StateMet_DQRLSAN',                 &
-     units = ''                                  &
-     ) ! TODO: Units?
+     units = 'kg kg-1 s-1'                       &
+     )
 
 arr(next()) = info_type_(                        &
      sname = 'StateMet_DTRAIN',                  &
@@ -4289,47 +4289,47 @@ arr(next()) = info_type_(                        &
 arr(next()) = info_type_(                        &
      sname = 'StateMet_PEDGE',                   &
      lname = 'StateMet_PEDGE',                   &
-     units = ''                                  &
-     ) ! TODO: Units?
+     units = 'hPa'                               &
+     )
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
 arr(next()) = info_type_(                        &
      sname = 'StateMet_PFICU',                   &
      lname = 'StateMet_PFICU',                   &
-     units = ''                                  &
-     ) ! TODO: Units?
+     units = 'kg m-2 s-1'                        &
+     )
 
 arr(next()) = info_type_(                        &
      sname = 'StateMet_PFILSAN',                 &
      lname = 'StateMet_PFILSAN',                 &
-     units = ''                                  &
-     ) ! TODO: Units?
+     units = 'kg m-2 s-1'                        &
+     )
 
 arr(next()) = info_type_(                        &
      sname = 'StateMet_PFLCU',                   &
      lname = 'StateMet_PFLCU',                   &
-     units = ''                                  &
-     ) ! TODO: Units?
+     units = 'kg m-2 s-1'                        &
+     )
 
 arr(next()) = info_type_(                        &
      sname = 'StateMet_PFLLSAN',                 &
      lname = 'StateMet_PFLLSAN',                 &
-     units = ''                                  &
-     ) ! TODO: Units?
+     units = 'kg m-2 s-1'                        &
+     )
 
 #endif
 
 arr(next()) = info_type_(                        &
      sname = 'StateMet_QI',                      &
      lname = 'StateMet_QI',                      &
-     units = 'kg / kg'                           &
+     units = 'kg kg-1'                           &
      )
 
 arr(next()) = info_type_(                        &
      sname = 'StateMet_QL',                      &
      lname = 'StateMet_QL',                      &
-     units = 'kg / kg'                           &
+     units = 'kg kg-1'                           &
      )
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
@@ -4337,13 +4337,14 @@ arr(next()) = info_type_(                        &
 arr(next()) = info_type_(                        &
      sname = 'StateMet_REEVAPCN',                &
      lname = 'StateMet_REEVAPCN',                &
-     units = 'kg / kg / s'                       &
+     units = 'kg kg-1 s-1'                       &
      )
 
+! NOTE: In GEOS-Chem/Header/state_met_mod.F90 the units are 'kg '. Typo?
 arr(next()) = info_type_(                        &
      sname = 'StateMet_REEVAPLS',                &
      lname = 'StateMet_REEVAPLS',                &
-     units = 'kg / kg / s'                       &
+     units = 'kg kg-1 s-1'                       &
      )
 
 #endif
@@ -4351,25 +4352,25 @@ arr(next()) = info_type_(                        &
 arr(next()) = info_type_(                        &
      sname = 'StateMet_RH',                      &
      lname = 'StateMet_RH',                      &
-     units = ''                                  &
+     units = '%'                                 &
      )
 
 arr(next()) = info_type_(                        &
      sname = 'StateMet_SPHU',                    &
      lname = 'StateMet_SPHU',                    &
-     units = 'g H2O / kg air'                    &
+     units = 'g kg-1'                            &
      )
 
 arr(next()) = info_type_(                        &
      sname = 'StateMet_SPHU1',                   &
      lname = 'StateMet_SPHU1',                   &
-     units = 'kg / kg'                           &
+     units = 'g kg-1'                            &
      )
 
 arr(next()) = info_type_(                        &
      sname = 'StateMet_SPHU2',                   &
      lname = 'StateMet_SPHU2',                   &
-     units = 'kg / kg'                           &
+     units = 'g kg-1'                            &
      )
 
 arr(next()) = info_type_(                        &
@@ -4415,7 +4416,7 @@ arr(next()) = info_type_(                        &
 arr(next()) = info_type_(                        &
      sname = 'StateMet_U',                       &
      lname = 'StateMet_U',                       &
-     units = 'm / s'                             &
+     units = 'm s-1'                             &
      )
 
 #ifdef MODEL_GEOS
@@ -4423,15 +4424,15 @@ arr(next()) = info_type_(                        &
 arr(next()) = info_type_(                        &
      sname = 'StateMet_UPDVVEL',                 &
      lname = 'StateMet_UPDVVEL',                 &
-     units = ''                                  &
-     ) ! TODO: Units?
+     units = 'hPa s-1'                           &
+     )
 
 #endif
 
 arr(next()) = info_type_(                        &
      sname = 'StateMet_V',                       &
      lname = 'StateMet_V',                       &
-     units = 'm / s'                             &
+     units = 'm s-1'                             &
      )
 
 return

--- a/model/CHEM_DRV.F90
+++ b/model/CHEM_DRV.F90
@@ -2264,22 +2264,76 @@ CONTAINS
        do k=1,subdd%ndiags
           ntm_loop: do n=1,State_Chm%nSpecies
              ! tracer 3D mixing ratios (SUBDD names are just tracer name):
-             if( trim( State_Chm%SpcData(N)%Info%Name ) .eq. trim(subdd%name(k)) ) then                
+             if( trim( State_Chm%SpcData(N)%Info%Name ) .eq. trim(subdd%name(k)) ) then
                 DO L=1,LmaxSUBDD
                 DO J=J_0,J_1
                 DO I=I_0,I_1
                    II = I - I_0 + 1
                    JJ = J - J_0 + 1
-                   sddarr3d(I,J,L) = State_Chm%Species(N)%Conc(II,JJ,L)         
+                   sddarr3d(I,J,L) = State_Chm%Species(N)%Conc(II,JJ,L)
                 ENDDO
                 ENDDO
                 ENDDO
 
-                ! TODO: State_Met%AD
-                ! TODO: State_Met%AIRDEN
-                ! TODO: State_Met%AIRVOL
-                ! TODO: State_Met%AVGW
-                ! TODO: State_Met%BXHEIGHT
+                if ( trim(subdd%name(k)) == "StateMet_AD" ) then
+                  DO L=1,LmaxSUBDD
+                  DO J=J_0,J_1
+                  DO I=I_0,I_1
+                      II = I - I_0 + 1
+                      JJ = J - J_0 + 1
+                      sddarr3d(I,J,L) = State_Met%AD(II,JJ,L)
+                  ENDDO
+                  ENDDO
+                  ENDDO
+                endif
+
+                if ( trim(subdd%name(k)) == "StateMet_AIRDEN" ) then
+                  DO L=1,LmaxSUBDD
+                  DO J=J_0,J_1
+                  DO I=I_0,I_1
+                      II = I - I_0 + 1
+                      JJ = J - J_0 + 1
+                      sddarr3d(I,J,L) = State_Met%AIRDEN(II,JJ,L)
+                  ENDDO
+                  ENDDO
+                  ENDDO
+                endif
+
+                if ( trim(subdd%name(k)) == "StateMet_AIRVOL" ) then
+                  DO L=1,LmaxSUBDD
+                  DO J=J_0,J_1
+                  DO I=I_0,I_1
+                      II = I - I_0 + 1
+                      JJ = J - J_0 + 1
+                      sddarr3d(I,J,L) = State_Met%AIRVOL(II,JJ,L)
+                  ENDDO
+                  ENDDO
+                  ENDDO
+                endif
+
+                if ( trim(subdd%name(k)) == "StateMet_AVGW" ) then
+                  DO L=1,LmaxSUBDD
+                  DO J=J_0,J_1
+                  DO I=I_0,I_1
+                      II = I - I_0 + 1
+                      JJ = J - J_0 + 1
+                      sddarr3d(I,J,L) = State_Met%AVGW(II,JJ,L)
+                  ENDDO
+                  ENDDO
+                  ENDDO
+                endif
+
+                if ( trim(subdd%name(k)) == "StateMet_BXHEIGHT" ) then
+                  DO L=1,LmaxSUBDD
+                  DO J=J_0,J_1
+                  DO I=I_0,I_1
+                      II = I - I_0 + 1
+                      JJ = J - J_0 + 1
+                      sddarr3d(I,J,L) = State_Met%BXHEIGHT(II,JJ,L)
+                  ENDDO
+                  ENDDO
+                  ENDDO
+                endif
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
@@ -2308,8 +2362,30 @@ CONTAINS
           endif
 
 #endif
-                ! TODO: State_Met%DELP
-                ! TODO: State_Met%DELPDRY
+
+                if ( trim(subdd%name(k)) == "StateMet_DELP" ) then
+                  DO L=1,LmaxSUBDD
+                  DO J=J_0,J_1
+                  DO I=I_0,I_1
+                      II = I - I_0 + 1
+                      JJ = J - J_0 + 1
+                      sddarr3d(I,J,L) = State_Met%DELP(II,JJ,L)
+                  ENDDO
+                  ENDDO
+                  ENDDO
+                endif
+
+                if ( trim(subdd%name(k)) == "StateMet_DELPDRY" ) then
+                  DO L=1,LmaxSUBDD
+                  DO J=J_0,J_1
+                  DO I=I_0,I_1
+                      II = I - I_0 + 1
+                      JJ = J - J_0 + 1
+                      sddarr3d(I,J,L) = State_Met%DELP_DRY(II,JJ,L)
+                  ENDDO
+                  ENDDO
+                  ENDDO
+                endif
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
@@ -2555,7 +2631,17 @@ CONTAINS
              ENDDO
           endif
 
-                ! TODO: State_Met%THETA
+                if ( trim(subdd%name(k)) == "StateMet_THETA" ) then
+                  DO L=1,LmaxSUBDD
+                  DO J=J_0,J_1
+                  DO I=I_0,I_1
+                      II = I - I_0 + 1
+                      JJ = J - J_0 + 1
+                      sddarr3d(I,J,L) = State_Met%THETA(II,JJ,L)
+                  ENDDO
+                  ENDDO
+                  ENDDO
+                endif
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
@@ -4083,14 +4169,37 @@ do n=1,nsp
        lname = trim(spname(n))//' mixing ratio', &
        units = 'mol mol-1'                       &
        )
-
 end do ! tracers loop
 
-       ! TODO: State_Met%AD
-       ! TODO: State_Met%AIRDEN
-       ! TODO: State_Met%AIRVOL
-       ! TODO: State_Met%AVGW
-       ! TODO: State_Met%BXHEIGHT
+arr(next()) = info_type_(                        &
+    sname = 'StateMet_AD',                       &
+    lname = 'StateMet_AD',                       &
+    units = 'kg'                                 &
+    )
+
+arr(next()) = info_type_(                        &
+    sname = 'StateMet_AIRDEN',                   &
+    lname = 'StateMet_AIRDEN',                   &
+    units = 'kg m-3'                             &
+    )
+
+arr(next()) = info_type_(                        &
+    sname = 'StateMet_AIRVOL',                   &
+    lname = 'StateMet_AIRVOL',                   &
+    units = 'm3'                                 &
+    )
+
+arr(next()) = info_type_(                        &
+    sname = 'StateMet_AVGW',                     &
+    lname = 'StateMet_AVGW',                     &
+    units = 'vol vol-1'                          &
+    )
+
+arr(next()) = info_type_(                        &
+    sname = 'StateMet_BXHEIGHT',                 &
+    lname = 'StateMet_BXHEIGHT',                 &
+    units = 'm'                                  &
+    )
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
@@ -4108,8 +4217,17 @@ end do ! tracers loop
 
 #endif
 
-       ! TODO: State_Met%DELP
-       ! TODO: State_Met%DELPDRY
+arr(next()) = info_type_(                        &
+    sname = 'StateMet_DELP',                     &
+    lname = 'StateMet_DELP',                     &
+    units = 'hPa'                                &
+    )
+
+arr(next()) = info_type_(                        &
+    sname = 'StateMet_DELPDRY',                  &
+    lname = 'StateMet_DELPDRY',                  &
+    units = 'hPa'                                &
+    )
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 
@@ -4241,7 +4359,11 @@ end do ! tracers loop
        units = 'K'                               &
        )
 
-       ! TODO: State_Met%THETA
+arr(next()) = info_type_(                        &
+    sname = 'StateMet_THETA',                    &
+    lname = 'StateMet_THETA',                    &
+    units = 'K'                                  &
+    )
 
 #ifdef CALC_MERRA2_LIKE_DIAGS
 


### PR DESCRIPTION
Towards #29.
Merges into #99.

This PR adds 3D diagnostics that weren't already included.

It also ensures that the correct units are used according to `GEOS-Chem/Headers/state_met_mod.F90` and applies consistent formatting.