### PR TITLE
Use `develop` branch for all submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "model/geos-chem/src/GEOS-Chem"]
 	path = model/geos-chem/src/GEOS-Chem
 	url = https://github.com/fetch4/geos-chem.git
-	branch = joe/14.4.3
+	branch = develop
 [submodule "model/geos-chem/src/HEMCO"]
 	path = model/geos-chem/src/HEMCO
 	url = https://github.com/fetch4/HEMCO.git
-	branch = joe/giss-gc-v14.4.3
+	branch = develop
 [submodule "model/geos-chem/src/Cloud-J"]
 	path = model/geos-chem/src/Cloud-J
 	url = https://github.com/fetch4/Cloud-J.git
-	branch = dev/giss-gc
+	branch = develop
 [submodule "model/geos-chem/src/HETP"]
 	path = model/geos-chem/src/HETP
   url = https://github.com/fetch4/HETerogeneous-vectorized-or-Parallel.git


### PR DESCRIPTION
I just noticed that the `.gitmodules` file isn't specifying the correct branches for the submodules. We should be using `develop` for GISS-GC, GEOS-Chem, and HEMCO.